### PR TITLE
bugfix: missing default value of LocationRequest.durationMillis

### DIFF
--- a/src/com/google/android/gms/location/LocationRequest.java
+++ b/src/com/google/android/gms/location/LocationRequest.java
@@ -24,7 +24,7 @@ public class LocationRequest extends SpReadOnly {
     @Property(8) public long maxUpdateDelayMillis;
     @Property(9) public boolean waitForAccurateLocation;
 
-    @Property(10) public long durationMillis;
+    @Property(10) public long durationMillis = Long.MAX_VALUE;
 
     /*
     unused for now:


### PR DESCRIPTION
LocationRequest.Builder.setDurationMillis() enforces durationMillis > 0,
which leads to a crash in apps that use previous versions of the
GMS Location client library.