### PR TITLE
ignore deprecated LocationRequest.durationMillis property

### DIFF
--- a/src/app/grapheneos/gmscompat/location/OsLocationListener.kt
+++ b/src/app/grapheneos/gmscompat/location/OsLocationListener.kt
@@ -33,7 +33,6 @@ fun LocationRequest.toOsLocationRequest(): android.location.LocationRequest {
     b.setMaxUpdates(maxUpdates)
     b.setMinUpdateDistanceMeters(minUpdateDistanceMeters)
     b.setMaxUpdateDelayMillis(maxUpdateDelayMillis)
-    b.setDurationMillis(durationMillis)
     return b.build()
 }
 

--- a/src/com/google/android/gms/location/LocationRequest.java
+++ b/src/com/google/android/gms/location/LocationRequest.java
@@ -24,19 +24,6 @@ public class LocationRequest extends SpReadOnly {
     @Property(8) public long maxUpdateDelayMillis;
     @Property(9) public boolean waitForAccurateLocation;
 
-    @Property(10) public long durationMillis = Long.MAX_VALUE;
-
-    /*
-    unused for now:
-
-    @Property(11) public long maxUpdateAgeMillis;
-    @Property(12) public int granularity;
-    @Property(13) public int throttleBehavior;
-    @Property(14) public String moduleId;
-    @Property(15) public boolean bypass;
-    @Property(16) public WorkSource workSource;
-     */
-
 // SafeParcel code block generated with Spoon | START
     public static final Parcelable.Creator<LocationRequest> CREATOR = new Parcelable.Creator<LocationRequest>() {
         public LocationRequest createFromParcel(Parcel p) {
@@ -71,9 +58,6 @@ public class LocationRequest extends SpReadOnly {
                         continue;
                     case 9 :
                         o.waitForAccurateLocation = SafeParcel.readBoolean(ph, p);
-                        continue;
-                    case 10 :
-                        o.durationMillis = SafeParcel.readLong(ph, p);
                         continue;
                     default :
                         SafeParcel.skipProp(ph, p);


### PR DESCRIPTION
Modern versions of play-services-location library use the expirationTime property instead.