### PR TITLE
notify the user about GMS crashes

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -58,6 +58,12 @@
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </activity>
+
+        <receiver
+            android:name=".CrashReceiver"
+            android:exported="true"
+            android:permission="app.grapheneos.gmscompat.SHOW_UI"
+        />
     </application>
 
     <queries>

--- a/res/drawable/ic_crash_report.xml
+++ b/res/drawable/ic_crash_report.xml
@@ -1,0 +1,11 @@
+<!--"report" symbol from Material Symbols-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M12,17Q12.425,17 12.713,16.712Q13,16.425 13,16Q13,15.575 12.713,15.287Q12.425,15 12,15Q11.575,15 11.288,15.287Q11,15.575 11,16Q11,16.425 11.288,16.712Q11.575,17 12,17ZM11,13H13V7H11ZM8.25,21 L3,15.75V8.25L8.25,3H15.75L21,8.25V15.75L15.75,21ZM9.1,19H14.9L19,14.9V9.1L14.9,5H9.1L5,9.1V14.9ZM12,12Z"/>
+</vector>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -67,4 +67,7 @@ To receive them quicker, set “Battery usage“ to “Unrestricted“ in Play s
     <string name="notif_bg_activity_start">%s needs to show a screen. Tap to allow</string>
 
     <string name="notif_missing_nearby_devices_perm_generic">%s needs the “Nearby devices“ permission</string>
+
+    <string name="notif_gms_crash_title">Sandboxed Google Play crashed</string>
+    <string name="notif_gms_crash_text">Tap to see the details</string>
 </resources>

--- a/src/app/grapheneos/gmscompat/CrashReceiver.kt
+++ b/src/app/grapheneos/gmscompat/CrashReceiver.kt
@@ -1,0 +1,59 @@
+package app.grapheneos.gmscompat
+
+import android.app.ApplicationErrorReport
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.os.SystemClock
+import java.util.*
+import java.util.concurrent.TimeUnit
+
+class CrashReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context?, intent: Intent?) {
+        val stackTrace = intent?.getParcelableExtra<ApplicationErrorReport>(Intent.EXTRA_BUG_REPORT)
+                ?.crashInfo?.stackTrace
+
+        if (stackTrace == null) {
+            return
+        }
+
+        val ts = SystemClock.elapsedRealtime()
+
+        synchronized(javaClass) {
+            if (stackTrace == prevNotifStackTrace) {
+                val prev = prevNotifTimestamp
+                if (prev != 0L && (ts - prev) < TimeUnit.MINUTES.toMillis(5)) {
+                    // don't spam notifications if GMS chain-crashes
+                    return
+                }
+            }
+            prevNotifStackTrace = stackTrace
+            prevNotifTimestamp = ts
+        }
+
+        val ctx = App.ctx()
+
+        intent.setComponent(ComponentName.createRelative("com.android.systemui", ".ErrorReportActivity"))
+        intent.setIdentifier(UUID.randomUUID().toString())
+
+        val pendingIntent = PendingIntent.getActivity(ctx, 0, intent,
+                PendingIntent.FLAG_ONE_SHOT or PendingIntent.FLAG_IMMUTABLE)
+
+        Notifications.builder(Notifications.CH_GMS_CRASHED).apply {
+            setContentTitle(ctx.getText(R.string.notif_gms_crash_title))
+            setContentText(ctx.getText(R.string.notif_gms_crash_text))
+            setContentIntent(pendingIntent)
+            setShowWhen(true)
+            setAutoCancel(true)
+            setSmallIcon(R.drawable.ic_crash_report)
+        }.show(Notifications.generateUniqueNotificationId())
+    }
+
+    companion object {
+        var prevNotifStackTrace: String? = null
+        var prevNotifTimestamp = 0L
+    }
+}

--- a/src/app/grapheneos/gmscompat/Notifications.kt
+++ b/src/app/grapheneos/gmscompat/Notifications.kt
@@ -14,6 +14,7 @@ object Notifications {
     const val CH_MISSING_PERMISSION = "missing_permission"
     const val CH_MISSING_PLAY_GAMES_APP = "missing_play_games_app"
     const val CH_BACKGROUND_ACTIVITY_START = "bg_activity_start"
+    const val CH_GMS_CRASHED = "gms_crashed"
 
     const val ID_PERSISTENT_FG_SERVICE = 1
     const val ID_PLAY_STORE_PENDING_USER_ACTION = 2
@@ -33,6 +34,7 @@ object Notifications {
             ch(CH_MISSING_PERMISSION, R.string.missing_permission, IMPORTANCE_HIGH),
             ch(CH_MISSING_PLAY_GAMES_APP, R.string.missing_play_games_app, IMPORTANCE_HIGH),
             ch(CH_BACKGROUND_ACTIVITY_START, R.string.notif_channel_bg_activity_start, IMPORTANCE_HIGH),
+            ch(CH_GMS_CRASHED, R.string.notif_gms_crash_title, IMPORTANCE_HIGH),
         )
 
         App.notificationManager().createNotificationChannels(list)
@@ -71,4 +73,3 @@ object Notifications {
 fun Notification.Builder.show(id: Int) {
     App.notificationManager().notify(id, this.build())
 }
-

--- a/src/app/grapheneos/gmscompat/PersistentFgService.java
+++ b/src/app/grapheneos/gmscompat/PersistentFgService.java
@@ -188,6 +188,8 @@ public class PersistentFgService extends Service {
         }
 
         public void onNullBinding(ComponentName name) {
+            svc.unbindService(this);
+
             String msg = "unable to bind " + name;
             if (pkg.equals(GmsInfo.PACKAGE_GMS_CORE) || pkg.equals(GmsInfo.PACKAGE_PLAY_STORE)) {
                 throw new IllegalStateException(msg);


### PR DESCRIPTION
The standard crash UI doesn't show up in many cases, eg when an app crashes for the first time,
or when it's in the background, or if it crashed multiple times recently.