### PR TITLE
config-holder: use a string resource to workaround AAPT2 bug

### DIFF
--- a/config-holder/app/AndroidManifest.xml
+++ b/config-holder/app/AndroidManifest.xml
@@ -3,7 +3,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
 >
     <application
-        android:label="${app_name}"
+        android:label="@string/app_name"
         android:hasCode="false"
     />
 </manifest>

--- a/config-holder/app/build.gradle.kts
+++ b/config-holder/app/build.gradle.kts
@@ -18,6 +18,7 @@ android {
 
     sourceSets.getByName("main") {
         manifest.srcFile("AndroidManifest.xml")
+        res.srcDir("res")
         resources.srcDir("../../gmscompat_config")
     }
 
@@ -41,7 +42,6 @@ android {
     buildTypes {
         getByName("release") {
             isMinifyEnabled = true
-            manifestPlaceholders["app_name"] = "GmsCompat config"
             if (useKeystoreProperties) {
                 signingConfig = signingConfigs.getByName("release")
             }
@@ -49,7 +49,6 @@ android {
         getByName("debug") {
             isMinifyEnabled = true
             applicationIdSuffix = ".dev"
-            manifestPlaceholders["app_name"] = "GmsCompat config dev"
         }
     }
 }

--- a/config-holder/app/res/values/strings.xml
+++ b/config-holder/app/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">GmsCompat config</string>
+</resources>


### PR DESCRIPTION
`aapt dump badging` doesn't print application-label when it's not defined as a resource string.
