### PR TITLE
fix disabling of com.google.android.westworld

### DIFF
--- a/gmscompat_config
+++ b/gmscompat_config
@@ -29,7 +29,8 @@ AccountCategoriesFeature__use_cp2_sim_account_settings perms-none-of android.per
 
 [com.google.android.westworld]
 # seems to be an OS stats/analytics service, requires privileged permissions to function
-enabled false
+is_enabled false
+metrics_enabled false
 
 [gservices]
 finsky.AppDependencyInstall__enable_request_install_access_filter set-string 1


### PR DESCRIPTION
"enabled" flag is checked in GmsCore code, but is not present in phenotype.db, not clear why.
A seemingly duplicate "is_enabled" flag is present in phenotype.db and is checked by GmsCore too.
Flags that aren't present in phenotype.db can't be overriden in GmsPhenotypeFlagsCursor.
