### PR TITLE
config: skip westworld's MetadataAlarmOperation

### DIFF
--- a/gmscompat_config
+++ b/gmscompat_config
@@ -31,6 +31,7 @@ AccountCategoriesFeature__use_cp2_sim_account_settings perms-none-of android.per
 # seems to be an OS stats/analytics service, requires privileged permissions to function
 is_enabled false
 metrics_enabled false
+metadata_enabled false
 
 [gservices]
 finsky.AppDependencyInstall__enable_request_install_access_filter set-string 1


### PR DESCRIPTION
It is scheduled via AlarmManager even if "is_enabled" flag is false.
MetadataAlarmOperation calls privileged StatsManager#getStatsMetadata(), which leads to a crash.
