### PR TITLE
location service bugfix: incorrect IStatusCallback API definition

### DIFF
--- a/src/app/grapheneos/gmscompat/location/GLocationService.kt
+++ b/src/app/grapheneos/gmscompat/location/GLocationService.kt
@@ -14,6 +14,7 @@ import android.os.CancellationSignal
 import android.os.RemoteException
 import android.util.SparseArray
 import com.google.android.gms.common.api.Status
+import com.google.android.gms.common.api.internal.IStatusCallback
 import com.google.android.gms.common.internal.ICancelToken
 import com.google.android.gms.location.ILocationCallback
 import com.google.android.gms.location.ILocationListener
@@ -28,7 +29,6 @@ import com.google.android.gms.location.internal.IGoogleLocationManagerService
 import com.google.android.gms.location.internal.ILocationAvailabilityStatusCallback
 import com.google.android.gms.location.internal.ILocationStatusCallback
 import com.google.android.gms.location.internal.ISettingsCallbacks
-import com.google.android.gms.location.internal.IStatusCallback
 import com.google.android.gms.location.internal.LocationRequestUpdateData
 import app.grapheneos.gmscompat.App
 import app.grapheneos.gmscompat.Const

--- a/src/com/google/android/gms/common/api/internal/IStatusCallback.aidl
+++ b/src/com/google/android/gms/common/api/internal/IStatusCallback.aidl
@@ -1,4 +1,4 @@
-package com.google.android.gms.location.internal;
+package com.google.android.gms.common.api.internal;
 
 import android.location.Location;
 

--- a/src/com/google/android/gms/location/internal/IGoogleLocationManagerService.aidl
+++ b/src/com/google/android/gms/location/internal/IGoogleLocationManagerService.aidl
@@ -5,6 +5,7 @@ import android.location.Location;
 import android.os.Bundle;
 
 import com.google.android.gms.common.api.Status;
+import com.google.android.gms.common.api.internal.IStatusCallback;
 import com.google.android.gms.common.internal.ICancelToken;
 import com.google.android.gms.location.CurrentLocationRequest;
 import com.google.android.gms.location.LastLocationRequest;
@@ -16,7 +17,6 @@ import com.google.android.gms.location.ILocationListener;
 import com.google.android.gms.location.internal.IFusedLocationProviderCallback;
 import com.google.android.gms.location.internal.ILocationStatusCallback;
 import com.google.android.gms.location.internal.ISettingsCallbacks;
-import com.google.android.gms.location.internal.IStatusCallback;
 import com.google.android.gms.location.internal.LocationReceiver;
 import com.google.android.gms.location.internal.LocationRequestInternal;
 import com.google.android.gms.location.internal.LocationRequestUpdateData;


### PR DESCRIPTION
Might cause issues with apps that check the result of (un)registerLocationReceiver() calls.
