### PR TITLE
Revert "config: spoof self checks of READ_PHONE_STATE permission"

### DIFF
--- a/gmscompat_config
+++ b/gmscompat_config
@@ -188,10 +188,3 @@ setSilenceMode false
 [android.bluetooth.BluetoothAdapter]
 registerBluetoothConnectionCallback false
 unregisterBluetoothConnectionCallback false
-
-[[spoof_self_permission_checks]]
-
-[com.google.android.gms]
-# GmsDeviceComplianceService is unavailable when GmsCore detects that it doesn't have this permission.
-# This service is needed for Play Integrity API to work.
-android.permission.READ_PHONE_STATE


### PR DESCRIPTION
This reverts commit 5aacabe0100826628d1a5f2071c8d3e06568b687.

Reason: makes FastPair service crash when it calls TelephonyManager.registerTelephonyCallback().