### PR TITLE
config: add stub for BluetoothDevice.getIdentityAddress

### DIFF
--- a/gmscompat_config
+++ b/gmscompat_config
@@ -99,6 +99,7 @@ registerBluetoothConnectionCallback default
 unregisterBluetoothConnectionCallback default
 
 [android.bluetooth.BluetoothDevice]
+getIdentityAddress default
 getMetadata default
 setMetadata default
 setSilenceMode default


### PR DESCRIPTION
GmsCore crashes in BleBondStateIntentOperation when it calls this method, which is protected by the BLUETOOTH_PRIVILEGED permission.