### PR TITLE
location service bugfix: incorrect definition of ICancelToken

### DIFF
--- a/src/app/grapheneos/gmscompat/MainFragment.kt
+++ b/src/app/grapheneos/gmscompat/MainFragment.kt
@@ -394,8 +394,5 @@ private fun intToBool(v: Int) =
     if (v == 1) {
         true
     } else {
-        if (IS_DEBUGGABLE) {
-            require(v == 0)
-        }
         false
     }

--- a/src/com/google/android/gms/common/internal/ICancelToken.aidl
+++ b/src/com/google/android/gms/common/internal/ICancelToken.aidl
@@ -1,5 +1,5 @@
 package com.google.android.gms.common.internal;
 
 interface ICancelToken {
-    void cancel() = 1;
+    oneway void cancel() = 1;
 }


### PR DESCRIPTION
In some cases, this made location service client crash when calling cancel() on ICancelToken
returned by getCurrentLocation().