### PR TITLE
location service bugfix: incorrect handling of request granularity 

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     package="app.grapheneos.gmscompat"
-    android:versionCode="1004"
+    android:versionCode="1005"
     android:versionName="1"
 >
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />

--- a/src/app/grapheneos/gmscompat/location/OsLocationProvider.kt
+++ b/src/app/grapheneos/gmscompat/location/OsLocationProvider.kt
@@ -40,6 +40,8 @@ class OsLocationProvider(val name: String, val properties: ProviderProperties?, 
             val fudger: LocationFudger? = when (client.permission) {
                 Permission.COARSE -> {
                     when (granularity) {
+                        LocationRequest.GRANULARITY_COARSE,
+                        LocationRequest.GRANULARITY_PERMISSION_LEVEL, -> null
                         LocationRequest.GRANULARITY_FINE -> throw SecurityException()
                         else -> throw IllegalArgumentException()
                     }


### PR DESCRIPTION
This led to crashes when client had only COARSE_LOCATION (not FINE_LOCATION) permission.

Closes https://github.com/GrapheneOS/os-issue-tracker/issues/2332