### PR TITLE
config: add stub for ActivityManager.addOnUidImportanceListener() 

### DIFF
--- a/gmscompat_config
+++ b/gmscompat_config
@@ -70,6 +70,9 @@ finsky.kill_switch_phenotype_gservices_check set-string 0
 
 [[stubs]]
 
+[android.app.ActivityManager]
+addOnUidImportanceListener void
+
 [android.app.admin.DevicePolicyManager]
 isDeviceProvisioned true
 isDeviceProvisioningConfigApplied true

--- a/gmscompat_config
+++ b/gmscompat_config
@@ -57,7 +57,6 @@ metadata_enabled false
 BugFixFeatures__fix_frp_in_r false
 
 [com.google.android.location]
-enable_app_importance_listener false
 # these flags are needed to prevent GmsCore from ignoring results of the legacy WifiManager#startScan()
 # method, which doesn't have an unprivileged modern version. It's used for location estimation based
 # on nearby Wi-Fi access points


### PR DESCRIPTION
It requires the special access PACKAGE_USAGE_STATS ("Usage access") permission that Play services
usually doesn't have.

removeOnUidImportanceListener() throws an IllegalArgumentException when trying to unregister an
unknown listener, but this is not an issue: app-side mImportanceListeners map is still updated
in addOnUidImportanceListener(), despite the listener registration being skipped.