### PR TITLE
config: fix incorrect kidssettings phenotype packageName

### DIFF
--- a/gmscompat_config
+++ b/gmscompat_config
@@ -63,7 +63,7 @@ BugFixFeatures__fix_frp_in_r false
 d_psl false
 fwm true
 
-[com.google.android.gms.kidssettings]
+[com.google.android.gms.kidssettings#com.google.android.gms]
 SeparateApkFeature__disable_separate_apk_if_not_used false
 
 [gservices]


### PR DESCRIPTION
autoSubpackage option is used for com.google.android.gms.kidssettings PhenotypeFlags.