### PR TITLE
increment overall GmsCompat version to 1007

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     package="app.grapheneos.gmscompat"
-    android:versionCode="1006"
+    android:versionCode="1007"
     android:versionName="1"
 >
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />


### PR DESCRIPTION
BLUETOOTH_PRIVILEGED_ANDROID_AUTO permission now allows BluetoothAdapter#getActiveDevices calls.