### PR TITLE
config: fix ActivityManager.getPackageImportance() stub

### DIFF
--- a/gmscompat_config
+++ b/gmscompat_config
@@ -78,8 +78,8 @@ finsky.kill_switch_phenotype_gservices_check set-string 0
 
 [android.app.ActivityManager]
 addOnUidImportanceListener void
-# 6 is ProcessState.IMPORTANCE_FOREGROUND
-getPackageImportance int 6
+# 2 is ProcessState.IMPORTANCE_TOP
+getPackageImportance int 2
 
 [android.app.admin.DevicePolicyManager]
 isDeviceProvisioned true


### PR DESCRIPTION
GmsCore location service requires its clients to have initial importance of at least IMPORTANCE_FOREGROUND_SERVICE (125), which corresponds to FOREGROUND_SERVICE (4) process state.

Clients that have a lower initial importance are not allowed to use most location service functionality, including fused location provider and fused device orientation provider.