### PR TITLE
config: add stub for BluetoothLeAdvertiser.startAdvertisingSet()

### DIFF
--- a/gmscompat_config
+++ b/gmscompat_config
@@ -119,6 +119,9 @@ setSilenceMode default
 [android.bluetooth.BluetoothManager]
 openGattServer default
 
+[android.bluetooth.le.BluetoothLeAdvertiser]
+startAdvertisingSet default
+
 [android.content.ContentResolver]
 registerContentObserver void
 


### PR DESCRIPTION
Closes https://github.com/GrapheneOS/os-issue-tracker/issues/3817