### PR TITLE
config-holder: enable generation of v4 APK signatures; config: GmsCore 24.35, Play Store 42.5

### DIFF
--- a/config-holder/app/build.gradle.kts
+++ b/config-holder/app/build.gradle.kts
@@ -43,6 +43,7 @@ android {
                 storePassword = keystoreProperties["storePassword"] as String
                 keyAlias = keystoreProperties["keyAlias"] as String
                 keyPassword = keystoreProperties["keyPassword"] as String
+                enableV4Signing = true
             }
         }
     }

--- a/gmscompat_config
+++ b/gmscompat_config
@@ -220,10 +220,10 @@ getPackagesForUid nullArray
 # section name is gmscompat version, section contents are max supported versions of GmsCore and Play Store
 [1000]
 # GmsCore 24.22 requires GmsCompat 1008
-242199999 84249999
+242199999 84259999
 
 [1008]
-243499999 84249999
+243599999 84259999
 
 [[stubs_12.1]]
 


### PR DESCRIPTION
Depends on https://github.com/GrapheneOS/apps.grapheneos.org/pull/131