### PR TITLE
fix "is dev build" checks

### DIFF
--- a/src/app/grapheneos/gmscompat/BinderDefs.kt
+++ b/src/app/grapheneos/gmscompat/BinderDefs.kt
@@ -4,11 +4,11 @@ import android.Manifest
 import android.app.ActivityManager
 import android.content.Intent
 import android.os.BinderDef
-import android.os.Build.IS_DEBUGGABLE
 import android.util.ArrayMap
 import android.util.ArraySet
 import androidx.core.content.edit
 import app.grapheneos.gmscompat.App.MainProcessPrefs
+import app.grapheneos.gmscompat.Const.IS_DEV_BUILD
 import app.grapheneos.gmscompat.location.GLocationService
 import com.android.internal.gmscompat.GmsInfo
 import com.android.internal.gmscompat.GmcBinderDefs.BinderDefStateListener
@@ -97,7 +97,7 @@ object BinderDefs {
         // Note that the callerPkg value is not verified at this point, verification is delayed
         // until the time of first use to reduce perf impact
 
-        if (IS_DEBUGGABLE) {
+        if (IS_DEV_BUILD) {
             logd{"caller $callerPkg processState ${ActivityManager.procStateToString(processState)} $ifaceName"}
         }
 

--- a/src/app/grapheneos/gmscompat/ConfigUpdateReceiver.java
+++ b/src/app/grapheneos/gmscompat/ConfigUpdateReceiver.java
@@ -4,12 +4,10 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
-import android.os.Build;
 import android.util.Log;
 
-import com.android.internal.gmscompat.GmsCompatConfig;
-
 import static android.os.PatternMatcher.PATTERN_LITERAL;
+import static app.grapheneos.gmscompat.Const.IS_DEV_BUILD;
 
 public class ConfigUpdateReceiver extends BroadcastReceiver {
     public static final String CONFIG_HOLDER_PACKAGE = "app.grapheneos.gmscompat.config";
@@ -20,7 +18,7 @@ public class ConfigUpdateReceiver extends BroadcastReceiver {
         filter.addDataScheme("package");
         filter.addDataSchemeSpecificPart(CONFIG_HOLDER_PACKAGE, PATTERN_LITERAL);
 
-        if (Build.isDebuggable()) {
+        if (IS_DEV_BUILD) {
             filter.addAction(Intent.ACTION_PACKAGE_ADDED);
             filter.addAction(Intent.ACTION_PACKAGE_REMOVED);
             filter.addDataSchemeSpecificPart(CONFIG_HOLDER_PACKAGE_DEV, PATTERN_LITERAL);

--- a/src/app/grapheneos/gmscompat/Const.java
+++ b/src/app/grapheneos/gmscompat/Const.java
@@ -1,5 +1,8 @@
 package app.grapheneos.gmscompat;
 
+import android.app.compat.gms.GmsCompat;
+
 public interface Const {
     boolean ENABLE_LOGGING = true;
+    boolean IS_DEV_BUILD = GmsCompat.isDevBuild();
 }

--- a/src/app/grapheneos/gmscompat/GmsCompatConfigParser.java
+++ b/src/app/grapheneos/gmscompat/GmsCompatConfigParser.java
@@ -6,7 +6,6 @@ import android.content.Context;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.os.Build;
-import android.os.Parcelable;
 import android.util.ArrayMap;
 import android.util.ArraySet;
 import android.util.Base64;
@@ -22,12 +21,9 @@ import java.io.InputStream;
 import java.io.InvalidObjectException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -35,16 +31,18 @@ import java.util.regex.PatternSyntaxException;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
+import static app.grapheneos.gmscompat.Const.IS_DEV_BUILD;
+
 public class GmsCompatConfigParser {
     private static final String TAG = "GmsCompatConfigParser";
 
-    private final boolean strict = Build.isDebuggable() && Build.VERSION.SDK_INT >= 33;
+    private final boolean strict = IS_DEV_BUILD && Build.VERSION.SDK_INT >= 33;
     private boolean invalid;
 
     private GmsCompatConfigParser() {}
 
     public static GmsCompatConfig exec(Context ctx) {
-        if (Build.isDebuggable()) {
+        if (IS_DEV_BUILD) {
             try {
                 GmsCompatConfig res = execInner(ctx, ConfigUpdateReceiver.CONFIG_HOLDER_PACKAGE_DEV);
                 return Objects.requireNonNull(res);
@@ -68,7 +66,7 @@ public class GmsCompatConfigParser {
     public static ApplicationInfo configHolderInfo(Context ctx) throws PackageManager.NameNotFoundException {
         var flags = PackageManager.ApplicationInfoFlags.of(0L);
         PackageManager pm = ctx.getPackageManager();
-        if (Build.isDebuggable()) {
+        if (IS_DEV_BUILD) {
             try {
                 return pm.getApplicationInfo(ConfigUpdateReceiver.CONFIG_HOLDER_PACKAGE_DEV, flags);
             } catch (PackageManager.NameNotFoundException e) {

--- a/src/app/grapheneos/gmscompat/NotableInterface.kt
+++ b/src/app/grapheneos/gmscompat/NotableInterface.kt
@@ -3,7 +3,7 @@ package app.grapheneos.gmscompat
 import android.Manifest
 import android.app.ActivityManager
 import android.content.Context
-import android.os.Build.IS_DEBUGGABLE
+import app.grapheneos.gmscompat.Const.IS_DEV_BUILD
 import com.android.internal.gmscompat.GmsInfo
 
 enum class NotableInterface(val ifaceName: String) {
@@ -13,7 +13,7 @@ enum class NotableInterface(val ifaceName: String) {
     ;
 
     fun onAcquiredByClient(callerPkg: String, processState: Int) {
-        if (IS_DEBUGGABLE) {
+        if (IS_DEV_BUILD) {
             logd{"pkgName $callerPkg, processState: ${ActivityManager.procStateToString(processState)}, ifaceName $ifaceName"}
         }
 


### PR DESCRIPTION
Build.IS_DEBUGGABLE and Build.isDebuggable() read ro.debuggable system property, which is unreadable by unprivileged apps since Android 14. Both of these checks always returned false as the result, which broke dev version of GmsCompatConfig.

Depends on https://github.com/GrapheneOS/platform_frameworks_base/pull/45