### PR TITLE
narrow down the SettingsLib dependency

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -14,9 +14,7 @@ android_app {
     ],
     static_libs: [
         "androidx.preference_preference",
-    ],
-    defaults: [
-        "SettingsLibDefaults",
+        "SettingsLibCollapsingToolbarBaseActivity",
     ],
     manifest: "AndroidManifest.xml",
 


### PR DESCRIPTION
This reduces APK size from ~10 MB to ~3.9 MB.