### PR TITLE
use fused provider instead of gps provider

### DIFF
--- a/src/app/grapheneos/gmscompat/location/OsLocationProvider.kt
+++ b/src/app/grapheneos/gmscompat/location/OsLocationProvider.kt
@@ -22,13 +22,13 @@ class OsLocationProvider(val name: String, val properties: ProviderProperties?, 
             val name = if (priority == LocationRequest.PRIORITY_NO_POWER) {
                 LocationManager.PASSIVE_PROVIDER
             } else {
-                LocationManager.GPS_PROVIDER
+                LocationManager.FUSED_PROVIDER
             }
             return get(client, name, granularity)
         }
 
         fun get(client: Client, granularity: Int): OsLocationProvider {
-            val name = LocationManager.GPS_PROVIDER
+            val name = LocationManager.FUSED_PROVIDER
             return get(client, name, granularity)
         }
 


### PR DESCRIPTION
allows other providers (such as the upcoming network location provider) to work when rerouting location requests to the OS

Google Maps wasn't using the network provider when rerouting location requests to the OS without this.