### PR TITLE
add GmsCore background data usage restriction notification; show GmsCore battery exemption notif once more if it was silenced before

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -84,7 +84,10 @@ To receive them quicker, set “Battery usage” to “Unrestricted” in Play s
     <string name="notif_gms_crash_report">Report to developers</string>
 
     <string name="notif_gmscore_power_exemption">
-"Push notifications will be delayed, because Play services app is not allowed to always run in the background. Tap to resolve."
+"Push notifications will be delayed because Play services app is not allowed to always run in the background. Tap to resolve."
+    </string>
+    <string name="notif_gmscore_background_data_exemption">
+"Push notifications will be delayed because Play services app is not allowed to use mobile data from the background. Tap to open Play services settings, which contain mobile data usage settings."
     </string>
     <string name="dont_show_again">Don\'t show again</string>
 

--- a/src/app/grapheneos/gmscompat/App.java
+++ b/src/app/grapheneos/gmscompat/App.java
@@ -72,7 +72,7 @@ public class App extends Application {
     public interface MainProcessPrefs {
         String LOCATION_REQUEST_REDIRECTION_ENABLED = "enabled_redirections"; // historical name
 
-        String GmsCore_POWER_EXEMPTION_PROMPT_DISMISSED = "GmsCore_power_exemption_prompt_dismissed";
+        String GmsCore_POWER_EXEMPTION_PROMPT_DISMISSED = "GmsCore_power_exemption_prompt_dismissed_2";
         String NOTIFICATION_DO_NOT_SHOW_AGAIN_PREFIX = "do_not_show_notification_";
 
         // set of package names of core GMS components that Play Store to allowed to update to unknown versions

--- a/src/app/grapheneos/gmscompat/App.java
+++ b/src/app/grapheneos/gmscompat/App.java
@@ -73,6 +73,7 @@ public class App extends Application {
         String LOCATION_REQUEST_REDIRECTION_ENABLED = "enabled_redirections"; // historical name
 
         String GmsCore_POWER_EXEMPTION_PROMPT_DISMISSED = "GmsCore_power_exemption_prompt_dismissed_2";
+        String GmsCore_BACKGROUND_DATA_EXEMPTION_PROMPT_DISMISSED = "GmsCore_background_data_exemption_prompt_dismissed";
         String NOTIFICATION_DO_NOT_SHOW_AGAIN_PREFIX = "do_not_show_notification_";
 
         // set of package names of core GMS components that Play Store to allowed to update to unknown versions

--- a/src/app/grapheneos/gmscompat/BinderGms2Gca.kt
+++ b/src/app/grapheneos/gmscompat/BinderGms2Gca.kt
@@ -534,4 +534,8 @@ object BinderGms2Gca : IGms2Gca.Stub() {
             show(notifId)
         }
     }
+
+    override fun maybeShowGmsCoreRestrictedBackgroundDataNotif() {
+        Notifications.handleGmsCoreRestrictedBackgroundDataNotif()
+    }
 }

--- a/src/app/grapheneos/gmscompat/Notifications.kt
+++ b/src/app/grapheneos/gmscompat/Notifications.kt
@@ -6,6 +6,8 @@ import android.app.NotificationManager
 import android.app.NotificationManager.IMPORTANCE_HIGH
 import android.app.compat.gms.GmsCompat
 import android.content.Intent
+import android.content.pm.PackageManager
+import android.ext.PackageId
 import android.net.Uri
 import android.os.PowerManager
 import android.provider.Settings
@@ -97,6 +99,11 @@ object Notifications {
         handledGmsCorePowerExemption = true
 
         val ctx = App.ctx()
+
+        if (ctx.packageManager.checkPermission(android.Manifest.permission.INTERNET,
+                PackageId.GMS_CORE_NAME) != PackageManager.PERMISSION_GRANTED) {
+            return
+        }
 
         if (App.preferences().getBoolean(MainProcessPrefs.GmsCore_POWER_EXEMPTION_PROMPT_DISMISSED, false)) {
             return


### PR DESCRIPTION
Depends on https://github.com/GrapheneOS/platform_frameworks_base/pull/69