### PR TITLE
location service: add back default values to API definitions

### DIFF
--- a/src/com/google/android/gms/location/CurrentLocationRequest.java
+++ b/src/com/google/android/gms/location/CurrentLocationRequest.java
@@ -8,10 +8,10 @@ import com.google.android.gms.RoSafeParcelable;
 // https://developers.google.com/android/reference/com/google/android/gms/location/CurrentLocationRequest
 @SafeParcelable.Class(creator = "CurrentLocationRequestCreator")
 public class CurrentLocationRequest extends RoSafeParcelable {
-    @Field(id = 1) public long maxUpdateAgeMillis = 60_000L;
-    @Field(id = 2) public int granularity = LocationRequest.GRANULARITY_PERMISSION_LEVEL;
-    @Field(id = 3) public int priority = LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY;
-    @Field(id = 4) public long durationMillis = Long.MAX_VALUE;
+    @Field(id = 1, defaultValue = "60000") public long maxUpdateAgeMillis;
+    @Field(id = 2, defaultValueUnchecked = "LocationRequest.GRANULARITY_PERMISSION_LEVEL")  public int granularity;
+    @Field(id = 3, defaultValueUnchecked = "LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY") public int priority;
+    @Field(id = 4, defaultValueUnchecked = "Long.MAX_VALUE") public long durationMillis;
 //    @Field(id = 5) public boolean bypass;
 //    @Field(id = 6) public WorkSource workSource;
 //    @Field(id = 7) public int throttleBehavior;

--- a/src/com/google/android/gms/location/LastLocationRequest.java
+++ b/src/com/google/android/gms/location/LastLocationRequest.java
@@ -8,8 +8,8 @@ import com.google.android.gms.RoSafeParcelable;
 // https://developers.google.com/android/reference/com/google/android/gms/location/LastLocationRequest
 @SafeParcelable.Class(creator = "LastLocationRequestCreator")
 public class LastLocationRequest extends RoSafeParcelable {
-    @Field(id = 1) public long maxAge;
-    @Field(id = 2) public int granularity;
+    @Field(id = 1, defaultValueUnchecked = "Long.MAX_VALUE") public long maxAge;
+    @Field(id = 2, defaultValueUnchecked = "LocationRequest.GRANULARITY_PERMISSION_LEVEL") public int granularity;
 //    @Field(id = 3) public boolean locationSettingsIgnored; // also named "bypass"
 //    @Field(id = 4) public String moduleId;
 //    @Field(id = 5) public ClientIdentity impersonation;

--- a/src/com/google/android/gms/location/LocationRequest.java
+++ b/src/com/google/android/gms/location/LocationRequest.java
@@ -28,14 +28,14 @@ public class LocationRequest extends RoSafeParcelable {
     @Field(id = 1) public int priority;
     @Field(id = 2) public long interval;
     @Field(id = 3) public long minUpdateIntervalMillis;
-    @Field(id = 5) public long expirationTime = Long.MAX_VALUE;
+    @Field(id = 5, defaultValueUnchecked = "Long.MAX_VALUE") public long expirationTime;
     @Field(id = 6) public int maxUpdates;
     @Field(id = 7) public float minUpdateDistanceMeters;
     @Field(id = 8) public long maxUpdateDelayMillis;
     @Field(id = 9) public boolean waitForAccurateLocation;
-    @Field(id = 10) public long durationMillis = Long.MAX_VALUE;
-    @Field(id = 11) public long maxUpdateAgeMillis = -1L;
-    @Field(id = 12) public int granularity = GRANULARITY_PERMISSION_LEVEL;
+    @Field(id = 10, defaultValueUnchecked = "Long.MAX_VALUE") public long durationMillis;
+    @Field(id = 11, defaultValue = "-1") public long maxUpdateAgeMillis;
+    @Field(id = 12, defaultValueUnchecked = "LocationRequest.GRANULARITY_PERMISSION_LEVEL") public int granularity;
     @Field(id = 13) public int throttleBehavior;
     @Field(id = 15) public boolean bypass;
     @Field(id = 16) public WorkSource workSource;


### PR DESCRIPTION
Their absence broke location service for some clients.