### PR TITLE
config: Move to in-place stubs for low-energy Bluetooth callback APIs

### DIFF
--- a/gmscompat_config
+++ b/gmscompat_config
@@ -128,16 +128,16 @@ setPairingConfirmation default
 setSilenceMode default
 
 [android.bluetooth.BluetoothHapClient]
-registerCallback void
-unregisterCallback void
+registerCallback default
+unregisterCallback default
 
 [android.bluetooth.BluetoothLeAudio]
-registerCallback void
-unregisterCallback void
+registerCallback default
+unregisterCallback default
 
 [android.bluetooth.BluetoothLeBroadcast]
-registerCallback void
-unregisterCallback void
+registerCallback default
+unregisterCallback default
 
 [android.bluetooth.BluetoothLeBroadcastAssistant]
 registerCallback void


### PR DESCRIPTION
Requires https://github.com/GrapheneOS/platform_packages_modules_Bluetooth/pull/57