### PR TITLE
add passkey support.

### DIFF
--- a/gmscompat_config
+++ b/gmscompat_config
@@ -17,6 +17,9 @@ PromoFeature__enabled perms-none-of android.permission.ACCESS_COARSE_LOCATION fa
 # below for increased stability
 Passkeys__client_data_hash_override_for_security_keys true
 
+[com.google.android.gms.auth.api.credentials]
+GisPasswordAndPasskeyProvider__no_cross_platform_create false
+
 [com.google.android.metrics]
 # controls access to privileged StatsManager#getRegisteredExperimentIds()
 add_external_experiment_ids false
@@ -207,7 +210,22 @@ getUserRestrictionSources emptyList
 isSafetyCenterEnabled false
 
 [android.security.keystore.recovery.RecoveryController]
+isRecoverableKeyStoreEnabled false
 initRecoveryService void
+getKeyChainSnapshot null
+setSnapshotCreatedPendingIntent void
+setServerParams void
+getAliases emptyList
+setRecoveryStatus void
+# RecoveryController.RECOVERY_STATUS_PERMANENT_FAILURE = 3
+getRecoveryStatus int 3
+setRecoverySecretTypes void
+getRecoverySecretTypes emptyIntArray
+generateKey throw android.security.keystore.recovery.InternalRecoveryServiceException
+importKey throw android.security.keystore.recovery.InternalRecoveryServiceException
+getKey throw java.security.UnrecoverableKeyException
+removeKey throw android.security.keystore.recovery.InternalRecoveryServiceException
+
 
 [android.telecom.TelecomManager]
 getAllPhoneAccountHandles emptyList


### PR DESCRIPTION
I have tested it on pixel 9a running 25.14.34 version of play services.

Features it enables.

- security key support for creating passkeys.
- Google play based passkeys.
- Cross device passkey support (yes one can scan qr code shown from another device using GrapheneOS's camera app and play service will create a passkey for it).
- All most all webiste that support fido2/passkey/webauth will work.


Tested with Vanadium & Chrome (Dev):

github.com
webauthn.io
passkeys.io
passkey.org


Tested with native app:

Whatsapp
Corbado Panel

Closes: [#5460](https://github.com/GrapheneOS/os-issue-tracker/issues/5460) , [#390](https://github.com/GrapheneOS/Vanadium/issues/390)