### PR TITLE
config: add stubs for AdvancedProtectionManager

### DIFF
--- a/gmscompat_config
+++ b/gmscompat_config
@@ -206,6 +206,11 @@ getUserRestrictionSources emptyList
 [android.safetycenter.SafetyCenterManager]
 isSafetyCenterEnabled false
 
+[android.security.advancedprotection.AdvancedProtectionManager]
+getAdvancedProtectionFeatures emptyList
+setAdvancedProtectionEnabled void
+logDialogShown void
+
 [android.security.keystore.recovery.RecoveryController]
 initRecoveryService void
 


### PR DESCRIPTION
Closes https://github.com/GrapheneOS/os-issue-tracker/issues/5810

Prevents the new Advanced Protection screen from crashing Play services. Note that this will make the enable toggle and the subsequent confirmation dialog that appears in Advanced Protection do nothing.

The other methods in AdvancedProtectionManager use android.permission.QUERY_ADVANCED_PROTECTION_MODE which is not privileged.