### PR TITLE
config: prevent Android Auto from going down bad assistant setup path

### DIFF
--- a/gmscompat_config
+++ b/gmscompat_config
@@ -88,6 +88,10 @@ fwm true
 [com.google.android.gms.kidssettings#com.google.android.gms]
 SeparateApkFeature__disable_separate_apk_if_not_used false
 
+[com.google.android.projection.gearhead]
+# prevent Android Auto from trying to query a nonexistent Assistant service in the Google app
+Assistant__dodgeboost_initial_handshake_enabled true
+
 [gservices]
 # make sure PhenotypeFlags are overridable by Gservices flags. Overriding Play Store (finsky) PhenotypeFlags
 # directly is much more complex than overriding Gservices flags.


### PR DESCRIPTION
If this flag is disabled, then Android Auto tries to query a service inside of com.google.android.googlequicksearchbox with this intent filter in order to connect to the Google assistant:

```
<intent-filter>
    <action android:name="android.intent.action.MAIN"/>
    <category android:name="com.google.android.car.category.CAR_ASSISTANT"/>
</intent-filter>
```

com.google.android.googlequicksearchbox as of version 16.38.63.ve.arm64 (301606314) doesn't have any services with this intent filter in its manifest. As a result, Android Auto will have the assistant uninitialized, because it'll be unable to resolve any intent services with that filter.

Enabling this flag will make Android Auto go into a different code path which seems to do assistant connection properly.