### PR TITLE
add support for overriding BinderProxy transactions; sign GmsCompatLib with a separate key to support out-of-band updates

### DIFF
--- a/lib/Android.bp
+++ b/lib/Android.bp
@@ -1,6 +1,7 @@
 android_app {
     name: "GmsCompatLib",
     platform_apis: true,
+    certificate: "gmscompat_lib",
     srcs: [
         "src/**/*.java",
         "src/**/*.aidl",

--- a/lib/src/app/grapheneos/gmscompat/lib/GmsCompatLibImpl.java
+++ b/lib/src/app/grapheneos/gmscompat/lib/GmsCompatLibImpl.java
@@ -1,14 +1,25 @@
 package app.grapheneos.gmscompat.lib;
 
+import android.annotation.Nullable;
 import android.content.Context;
 import android.content.Intent;
 import android.content.ServiceConnection;
+import android.os.BinderProxy;
+import android.os.IBinder;
+import android.os.IInterface;
 import android.os.UserHandle;
+import android.util.ArrayMap;
 import android.util.Log;
 
 import com.android.internal.gmscompat.IGmsCompatLib;
 
+import java.io.FileDescriptor;
+import java.util.Arrays;
+import java.util.function.Function;
+
 import app.grapheneos.gmscompat.lib.playintegrity.PlayIntegrityUtils;
+import app.grapheneos.gmscompat.lib.sysservice.SystemServiceOverridesRegistry;
+import app.grapheneos.gmscompat.lib.util.BinderUtils;
 
 /**
  * GmsCompatLibrary code is loaded into processes of apps that use GmsCompat.
@@ -17,13 +28,41 @@ public class GmsCompatLibImpl implements IGmsCompatLib {
     private static final String TAG = "GmcLib";
 
     @Override
-    public void init(Context appContext, String processName) {
+    public void init(Context appContext, Context libContext, String processName) {
         Log.d(TAG, "init: pkg: " + appContext.getPackageName() + ", process: " + processName);
+        SystemServiceOverridesRegistry.init(appContext, binderProxyOverridesRegistry);
     }
 
     @Override
     public ServiceConnection maybeReplaceServiceConnection(Intent service, long flags, UserHandle user, ServiceConnection orig) {
         ServiceConnection override = PlayIntegrityUtils.maybeReplaceServiceConnection(service, orig);
         return override;
+    }
+
+    private static final String TAG_BINDER = "GmcLibBinder";
+    private final ArrayMap<String, Function<IBinder, IInterface>> binderProxyOverridesRegistry = new ArrayMap<>();
+
+    @Nullable
+    @Override
+    public IInterface maybeProvideBinderProxyInterface(BinderProxy binderProxy, String ifaceDescriptor) {
+        if (Log.isLoggable(TAG_BINDER, Log.DEBUG)) {
+            Log.d(TAG_BINDER, "maybeProvideBinderProxyInterface: " + ifaceDescriptor + " | " + BinderUtils.getInterfaceDescriptor(binderProxy), maybeStackTrace(TAG_BINDER));
+        }
+
+        Function<IBinder, IInterface> creator = binderProxyOverridesRegistry.get(ifaceDescriptor);
+        if (creator == null) {
+            return null;
+        }
+        String actualIfaceDescriptor = BinderUtils.getInterfaceDescriptor(binderProxy);
+        if (!ifaceDescriptor.equals(actualIfaceDescriptor)) {
+            Log.w(TAG, "interface descriptor mismatch: expected " + ifaceDescriptor + " got " + actualIfaceDescriptor);
+            return null;
+        }
+        return creator.apply(binderProxy);
+    }
+
+    @Nullable
+    private static Throwable maybeStackTrace(String tag) {
+        return Log.isLoggable(tag, Log.VERBOSE) ? new Throwable() : null;
     }
 }

--- a/lib/src/app/grapheneos/gmscompat/lib/GmsCompatLibImpl.java
+++ b/lib/src/app/grapheneos/gmscompat/lib/GmsCompatLibImpl.java
@@ -61,6 +61,14 @@ public class GmsCompatLibImpl implements IGmsCompatLib {
         return creator.apply(binderProxy);
     }
 
+    @Override
+    public boolean maybeInterceptBinderProxyDump(BinderProxy binderProxy, FileDescriptor fd, String[] args, boolean async) {
+        if (Log.isLoggable(TAG_BINDER, Log.DEBUG)) {
+            Log.d(TAG_BINDER, "maybeInterceptBinderProxyDump: " + BinderUtils.getInterfaceDescriptor(binderProxy) + " " + Arrays.toString(args), maybeStackTrace(TAG_BINDER));
+        }
+        return false;
+    }
+
     @Nullable
     private static Throwable maybeStackTrace(String tag) {
         return Log.isLoggable(tag, Log.VERBOSE) ? new Throwable() : null;

--- a/lib/src/app/grapheneos/gmscompat/lib/sysservice/SystemServiceOverridesRegistry.java
+++ b/lib/src/app/grapheneos/gmscompat/lib/sysservice/SystemServiceOverridesRegistry.java
@@ -1,0 +1,29 @@
+package app.grapheneos.gmscompat.lib.sysservice;
+
+import android.app.ActivityManager;
+import android.app.ActivityThread;
+import android.app.IActivityManager;
+import android.app.SystemServiceRegistry;
+import android.app.compat.gms.GmsCompat;
+import android.content.Context;
+import android.content.pm.IPackageManager;
+import android.hardware.display.DisplayManagerGlobal;
+import android.os.IBinder;
+import android.os.IInterface;
+import android.util.ArrayMap;
+
+import java.util.function.Function;
+
+public class SystemServiceOverridesRegistry {
+
+    public static void init(Context appContext, ArrayMap<String, Function<IBinder, IInterface>> registry) {
+        // Clear cached binder wrappers to support overriding them through the
+        // maybeProvideBinderProxyInterface() below.
+        // Few wrappers are cached at this point and all or almost all of them are backed by cached
+        // binders, i.e. their reinitialization will happen locally, without IPC
+        ActivityManager.clearCachedService();
+        ActivityThread.clearCachedPackageManager();
+        DisplayManagerGlobal.clearCachedInstance();
+        SystemServiceRegistry.clearServiceCache(appContext);
+    }
+}

--- a/lib/src/app/grapheneos/gmscompat/lib/util/BinderUtils.java
+++ b/lib/src/app/grapheneos/gmscompat/lib/util/BinderUtils.java
@@ -1,0 +1,20 @@
+package app.grapheneos.gmscompat.lib.util;
+
+import android.annotation.Nullable;
+import android.os.IBinder;
+import android.os.RemoteException;
+import android.util.Log;
+
+public class BinderUtils {
+    private static final String TAG = "BinderUtils";
+
+    @Nullable
+    public static String getInterfaceDescriptor(IBinder binder) {
+        try {
+            return binder.getInterfaceDescriptor();
+        } catch (RemoteException e) {
+            Log.d(TAG, "", e);
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Part of a changelist:

https://github.com/GrapheneOS/platform_frameworks_base/pull/261
https://github.com/GrapheneOS/platform_system_tools_aidl/pull/1

https://github.com/GrapheneOS/platform_build/pull/76
https://github.com/GrapheneOS/script/pull/94

https://github.com/GrapheneOS/platform_build_release/pull/38

https://github.com/GrapheneOS/platform_manifest/pull/81