### PR TITLE
fix Gmail attachment sending

### DIFF
--- a/gmscompat_config
+++ b/gmscompat_config
@@ -102,6 +102,10 @@ finsky.kill_switch_phenotype_gservices_check set-string 0
 # disable GmsCore OS update service
 update_service_enabled set-string 0
 
+[gmail_android.user#com.google.android.gm]
+# fix Gmail attachment sending
+45633067 true
+
 [[stubs]]
 
 [android.app.ActivityManager]


### PR DESCRIPTION
See https://github.com/GrapheneOS/os-issue-tracker/issues/6770

When sending an email containing an attachment, the following error appears with log tag `nre` under the `com.google.android.gm` package:

```
E  [Gmail] SyncAdapterDelegate: Failed to sync using GIG for: 7********.
java.util.concurrent.ExecutionException: java.lang.IllegalStateException: Required value was null.
	at brmm.g(PG:21)
	at brmm.get(PG:389)
	at mxz.q(PG:1)
	at xll.a(PG:575)
	at xlm.d(PG:143)
	at kbi.onPerformSync(PG:11)
	at xlm.onPerformSync(PG:185)
	at android.content.AbstractThreadedSyncAdapter$SyncThread.run(AbstractThreadedSyncAdapter.java:354)
Caused by: java.lang.IllegalStateException: Required value was null.
	at wiz.d(PG:14)
	at vbx.i(PG:77)
	at vcg.a(PG:573)
	at brng.a(PG:57)
	at brmr.c(PG:3)
	at brmt.run(PG:38)
	at brpk.run(PG:3)
	at brpl.run(PG:196)
	at ajad.run(PG:7)
	at brdg.run(PG:44)
	at inb.run(PG:469)
	at java.lang.Thread.run(Thread.java:1563)
	at ajau.run(PG:61)
```

Inside of the `vbx` class (ComposeUploader), the constructor reads the flag 45633067 under the package `gmail_android.user#com.google.android.gm` via `Z.aX(account)` (an account-based flag). Then inside of the static `wlj#p` method, it chooses between two different implementations of the `wih` interface depending on the flag value.

If the flag value is false, it will choose the `wiz` class, which, for some reason, unconditionally throws the IllegalStateException saying the "Required value was null" in its implementation of the `d` method.

If the flag value is true, it will choose the `wit` class, which actually has a functional version of the `d` method. Enabling this flag also appears to resolve errors involving blocking threads, i.e. the errors that look like

```

E  BlockableFutures: Cannot block on non-blocking thread
java.lang.IllegalStateException: Cannot block on non-blocking thread: BG Thread #1
	at ajan.b(PG:109)
	at ajan.a(PG:1)
	at pho.a(PG:173)
	at vmm.f(PG:228)
	at vmj.b(PG:911)
	at cays.w(PG:12)
	at cbgm.run(PG:107)
	at bmmd.run(PG:588)
	at ajad.run(PG:7)
	at brdg.run(PG:44)
	at inb.run(PG:469)
	at java.lang.Thread.run(Thread.java:1563)
	at ajau.run(PG:61)
```

Test: On an existing `user` build signed with release keys, enabling this flag makes Gmail attachment sending work again.