### PR TITLE
update name of dynamiteFileProxyService

### DIFF
--- a/src/app/grapheneos/gmscompat/BinderClientOfGmsCore2Gca.kt
+++ b/src/app/grapheneos/gmscompat/BinderClientOfGmsCore2Gca.kt
@@ -18,7 +18,7 @@ import android.provider.Settings
 import android.util.Log
 import androidx.core.content.getSystemService
 import com.android.internal.gmscompat.IClientOfGmsCore2Gca
-import com.android.internal.gmscompat.dynamite.server.IFileProxyService
+import com.android.internal.gmscompat.fileservice.IFileProxyService
 
 object BinderClientOfGmsCore2Gca : IClientOfGmsCore2Gca.Stub() {
 
@@ -26,7 +26,7 @@ object BinderClientOfGmsCore2Gca : IClientOfGmsCore2Gca.Stub() {
         return BinderDefs.maybeGetBinderDef(callerPkg, processState, ifaceName, false)
     }
 
-    override fun getDynamiteFileProxyService(): IFileProxyService = BinderGms2Gca.dynamiteFileProxyService!!
+    override fun getGmsCoreFileProxyService(): IFileProxyService = BinderGms2Gca.gmsCoreFileProxyService!!
 
     override fun showMissingAppNotification(pkgName: String) {
         val prompt = when (pkgName) {

--- a/src/app/grapheneos/gmscompat/BinderGms2Gca.kt
+++ b/src/app/grapheneos/gmscompat/BinderGms2Gca.kt
@@ -30,7 +30,7 @@ import com.android.internal.gmscompat.GmsInfo.PACKAGE_GMS_CORE
 import com.android.internal.gmscompat.GmsInfo.PACKAGE_PLAY_STORE
 import com.android.internal.gmscompat.IGca2Gms
 import com.android.internal.gmscompat.IGms2Gca
-import com.android.internal.gmscompat.dynamite.server.IFileProxyService
+import com.android.internal.gmscompat.fileservice.IFileProxyService
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.function.Consumer
@@ -183,11 +183,11 @@ object BinderGms2Gca : IGms2Gca.Stub() {
     }
 
     @Volatile
-    var dynamiteFileProxyService: IFileProxyService? = null
+    var gmsCoreFileProxyService: IFileProxyService? = null
 
     override fun connectGmsCore(processName: String, iGca2Gms: IGca2Gms, fileProxyService: IFileProxyService?): GmsCompatConfig {
         if (fileProxyService != null) {
-            dynamiteFileProxyService = fileProxyService
+            gmsCoreFileProxyService = fileProxyService
         }
 
         if (processName == GmsHooks.PERSISTENT_GmsCore_PROCESS) {


### PR DESCRIPTION
This FileProxyService is now used for both Dynamite modules and phenotype flag files.