### PR TITLE
stub BluetoothA2dp.getConnectionPolicy to fix Android Auto crash

### DIFF
--- a/gmscompat_config
+++ b/gmscompat_config
@@ -130,6 +130,8 @@ getAppStandbyBucket int 10
 
 [android.bluetooth.BluetoothA2dp]
 setConnectionPolicy false
+# -1 is CONNECTION_POLICY_UNKNOWN
+getConnectionPolicy int -1
 
 [android.bluetooth.BluetoothAdapter]
 disable false


### PR DESCRIPTION
Android Auto build 164661034 calls `getConnectionPolicy()` during `onServiceConnected`,  which requires `BLUETOOTH_PRIVILEGED`. The set counterpart was stubbed in config-167; this adds the missing get stub returning `CONNECTION_POLICY_UNKNOWN (-1)`. Fixes #7484.