### PR TITLE
BinderGms2Gca, OsLocationListener: fix connect race, flush hazards, callerPkg spoofing

### DIFF
--- a/src/app/grapheneos/gmscompat/BinderGms2Gca.kt
+++ b/src/app/grapheneos/gmscompat/BinderGms2Gca.kt
@@ -280,6 +280,7 @@ object BinderGms2Gca : IGms2Gca.Stub() {
     }
 
     override fun startActivityFromTheBackground(callerPkg: String, intent: PendingIntent) {
+        verifyCallerPkg(callerPkg)
         val ctx = App.ctx()
         Notifications.builder(Notifications.CH_BACKGROUND_ACTIVITY_START)
                 .setSmallIcon(R.drawable.ic_configuration_required)
@@ -523,6 +524,7 @@ object BinderGms2Gca : IGms2Gca.Stub() {
     val missingPostNotifsNotifIds = ArrayMap<String, Int>()
 
     override fun showMissingPostNotifsPermissionNotification(callerPkg: String) {
+        verifyCallerPkg(callerPkg)
         val notifId = synchronized(missingPostNotifsNotifIds) {
             missingPostNotifsNotifIds.getOrPut(callerPkg) {
                 Notifications.generateUniqueNotificationId()

--- a/src/app/grapheneos/gmscompat/BinderGms2Gca.kt
+++ b/src/app/grapheneos/gmscompat/BinderGms2Gca.kt
@@ -54,6 +54,8 @@ object BinderGms2Gca : IGms2Gca.Stub() {
         Log.d(TAG, "connect from $pkg|$processName, pid ${boundProcess.pid}")
 
         val deathRecipient = DeathRecipient(iGca2Gms)
+        // must be before linkToDeath() to ensure binderDied() always has a matching requestStart()
+        val persistentFgServiceLatch = PersistentFgService.requestStart()
         try {
             // important to add before linkToDeath() to avoid race with binderDied() callback
             addBoundProcess(iGca2Gms, boundProcess)
@@ -63,7 +65,6 @@ object BinderGms2Gca : IGms2Gca.Stub() {
             deathRecipient.binderDied()
             throw e
         }
-        val persistentFgServiceLatch = PersistentFgService.requestStart()
 
         // Config holder update event might be delivered after GMS process starts if both
         // GMS component and GmsCompatConfig holder are updated together, atomically.

--- a/src/app/grapheneos/gmscompat/location/OsLocationListener.kt
+++ b/src/app/grapheneos/gmscompat/location/OsLocationListener.kt
@@ -10,6 +10,7 @@ import com.google.android.gms.location.LocationAvailability
 import com.google.android.gms.location.LocationRequest
 import java.util.Collections
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import kotlin.math.max
 import kotlin.math.min
 
@@ -107,24 +108,46 @@ class OsLocationListener(val client: Client, val provider: OsLocationProvider,
         onLocationAvailabilityChanged(false)
     }
 
+    private val flushLock = Any()
+    private var nextFlushRequestCode = 0
+    @Volatile
+    private var activeFlushRequestCode = 0
+    @Volatile
     private var flushLatch: CountDownLatch? = null
 
     fun flush() {
-        val l = CountDownLatch(1)
-        synchronized(this) {
+        // flushLock serializes flushes on the same listener; the request code lets
+        // onFlushComplete() ignore late callbacks from a previous timed-out flush
+        synchronized(flushLock) {
+            val l = CountDownLatch(1)
+            val code = ++nextFlushRequestCode
+            // publish before requestFlush() so a fast callback sees them
             flushLatch = l
+            activeFlushRequestCode = code
             try {
-                client.locationManager.requestFlush(provider.name, this, 0)
+                client.locationManager.requestFlush(provider.name, this, code)
             } catch (e: IllegalStateException) {
                 // may get thrown if other thread unregisters this listener
+                flushLatch = null
                 return
             }
-            l.await()
-            flushLatch = null
+            try {
+                // bounded wait: a flush callback is not guaranteed to arrive if this listener
+                // gets unregistered concurrently
+                if (!l.await(5, TimeUnit.SECONDS)) {
+                    logd{"flush timed out"}
+                }
+            } catch (e: InterruptedException) {
+                Thread.currentThread().interrupt()
+            } finally {
+                flushLatch = null
+            }
         }
     }
 
     override fun onFlushComplete(requestCode: Int) {
-        flushLatch!!.countDown()
+        if (requestCode == activeFlushRequestCode) {
+            flushLatch?.countDown()
+        }
     }
 }


### PR DESCRIPTION
**`BinderGms2Gca`: avoid `PersistentFgService` refcount underflow on connect race**

`requestStart()` was called after `linkToDeath()`. `binderDied()` could fire - synchronously via the `RemoteException` catch path, or asynchronously from the binder driver - before its matching `requestStart()`, decrementing the refcount below zero and crashing. Fix: move `requestStart()` ahead of the `linkToDeath()` block.

**`OsLocationListener`: fix `flush()` races**

Three problems on the same path:

1. The `await()` was unbounded and held the listener monitor. If the listener was unregistered concurrently, the platform may never deliver `onFlushComplete`, permanently blocking the binder thread.
2. `flushLatch` was shared with no serialization, so two concurrent flushes could clobber each other's latch and complete the wrong waiter.
3. All flushes used request code `0`, so a late callback from a timed-out flush could prematurely complete the next flush.

Fix: bounded 5 s `await`, private `flushLock` for serialization (without holding the listener monitor), unique request code per flush that `onFlushComplete()` matches against, and latch state published before `requestFlush()` so a fast callback isn't dropped.

**`BinderGms2Gca`: verify `callerPkg` in `IGms2Gca` entry points that use it**

`startActivityFromTheBackground()` and `showMissingPostNotifsPermissionNotification()` accepted `callerPkg` unverified. Both are reachable from any GmsCompat-enabled app via `RpcProvider`, and both use `callerPkg` to label notifications and pick per-package state, allowing a GmsCompat-enabled client to display actions under another app's name. Fix: `verifyCallerPkg(callerPkg)` at the top of each method. Shared-UID packages can still pass each other's names - that follows Android's UID identity model.