### PR TITLE
lib: stub CarrierConfigManager.getConfigForSubId for Android Auto

### DIFF
--- a/lib/src/app/grapheneos/gmscompat/lib/sysservice/GmcCarrierConfigLoader.java
+++ b/lib/src/app/grapheneos/gmscompat/lib/sysservice/GmcCarrierConfigLoader.java
@@ -1,0 +1,54 @@
+package app.grapheneos.gmscompat.lib.sysservice;
+
+import android.os.IBinder;
+import android.os.PersistableBundle;
+import android.os.RemoteException;
+import android.util.Log;
+
+import com.android.internal.telephony.ICarrierConfigLoader;
+
+class GmcCarrierConfigLoader extends ICarrierConfigLoader.Stub.Proxy {
+    static final String TAG = "GmcCarrierConfigLoader";
+
+    protected GmcCarrierConfigLoader(IBinder remote) {
+        super(remote);
+    }
+
+    @Override
+    public PersistableBundle getConfigForSubId(int subId, String callingPackage)
+            throws RemoteException {
+        try {
+            return super.getConfigForSubId(subId, callingPackage);
+        } catch (SecurityException e) {
+            return nullCarrierConfig("getConfigForSubId", subId);
+        }
+    }
+
+    @Override
+    public PersistableBundle getConfigForSubIdWithFeature(int subId, String callingPackage,
+            String callingFeatureId) throws RemoteException {
+        try {
+            return super.getConfigForSubIdWithFeature(subId, callingPackage, callingFeatureId);
+        } catch (SecurityException e) {
+            return nullCarrierConfig("getConfigForSubIdWithFeature", subId);
+        }
+    }
+
+    @Override
+    public PersistableBundle getConfigSubsetForSubIdWithFeature(int subId, String callingPackage,
+            String callingFeatureId, String[] carrierConfigs) throws RemoteException {
+        try {
+            return super.getConfigSubsetForSubIdWithFeature(subId, callingPackage, callingFeatureId,
+                    carrierConfigs);
+        } catch (SecurityException e) {
+            Log.d(TAG, "getConfigSubsetForSubIdWithFeature: returning empty carrier config for subId "
+                    + subId);
+            return new PersistableBundle();
+        }
+    }
+
+    private static PersistableBundle nullCarrierConfig(String method, int subId) {
+        Log.d(TAG, method + ": returning null carrier config for subId " + subId);
+        return null;
+    }
+}

--- a/lib/src/app/grapheneos/gmscompat/lib/sysservice/SystemServiceOverridesRegistry.java
+++ b/lib/src/app/grapheneos/gmscompat/lib/sysservice/SystemServiceOverridesRegistry.java
@@ -13,6 +13,8 @@ import android.os.IBinder;
 import android.os.IInterface;
 import android.util.ArrayMap;
 
+import com.android.internal.telephony.ICarrierConfigLoader;
+
 import java.util.function.Function;
 
 import app.grapheneos.gmscompat.lib.GmsCompatLibImpl;
@@ -32,6 +34,9 @@ public class SystemServiceOverridesRegistry {
 
         if (GmsCompat.isEnabled()) {
             registry.put(IActivityManager.Stub.DESCRIPTOR, GmcActivityManager::new);
+            if (GmsCompat.isAndroidAuto()) {
+                registry.put(ICarrierConfigLoader.Stub.DESCRIPTOR, GmcCarrierConfigLoader::new);
+            }
         } else if (AppGlobals.getInitialPackageId() == PackageId.G_CAMERA) {
             ClientServiceOverridesRegistry.init(registry);
         }


### PR DESCRIPTION
Closes https://github.com/GrapheneOS/os-issue-tracker/issues/7780

Android Auto 16.6.661444 now declares `READ_BASIC_PHONE_STATE` which has normal protection level, so it will be granted even if user doesn't grant permissions to Android Auto to manage phone calls in Sandboxed Google Play settings  `TelephonyManager#getDataNetworkType()` accepts `READ_BASIC_PHONE_STATE`:
https://github.com/GrapheneOS/platform_frameworks_base/blob/2026050900/telephony/java/android/telephony/TelephonyManager.java#L3241

In Android Auto 16.6, when `getDataNetworkType` returns, e.g., `TelephonyManager.NETWORK_TYPE_LTE` (13), Android Auto enters its LTE carrier config branch and may call `CarrierConfigManager#getConfigForSubId()`.

GmsCompat spoofs Android Auto’s self-check for `READ_PHONE_STATE` (https://github.com/GrapheneOS/platform_packages_apps_GmsCompat/blob/config-169/gmscompat_config#L341), so Android Auto’s own guard passes even if `READ_PHONE_STATE` permission is denied. If the user didn't grant Android Auto permission to make calls in GmsCompat settings, system_server then throws `SecurityException` from `getCarrierConfig`.

In the previous version of Android Auto (16.4), it didn't have `READ_BASIC_PHONE_STATE` which made `getDataNetworkType()` fall back to checking full `READ_PHONE_STATE` or carrier privileges. This would fail the system_server permission check, but GmsCompat stubs `getDataNetworkType()` to `NETWORK_TYPE_UNKNOWN`:
https://github.com/GrapheneOS/platform_packages_apps_GmsCompat/blob/config-169/gmscompat_config#L266. Returning `NETWORK_TYPE_UNKNOWN` made Android Auto avoid that path with `CarrierConfigManager#getConfigForSubId()`

Just stub out this new call that gets reached. It should make Android Auto revert back to system resources. Note that `CarrierConfigManager#getConfigForSubId` has two overloads. The two overloads are marked differently: the one that Android Auto uses is nullable and deprecated while the other is nonnull. GmsCompatConfig doesn't support overloads and would match both; stubbing it to null would violate nonnull for non-deprecated override. GmsCompatConfig also doesn't support PersistableBundle.

Since Android Auto is calling a deprecated overload, we also preemptively add stubs for the non-null, non-deprecated overload for `getConfigForSubId` as well in case it's changed in the future.

Test: Android Auto 16.6.661444 no longer crashes on connection with "Allow permissions for handling phone calls" denied in Sandboxed Google Play settings. Cellular signal icon is still showing and functional when combined with the adevtool patch to remove satellite feature declaration. Answering/making/hanging up call support is functional when the permission is granted.