### PR TITLE
Add stub for TelephonyManager.getIccAuthentication

### DIFF
--- a/gmscompat_config
+++ b/gmscompat_config
@@ -279,6 +279,7 @@ getGroupIdLevel1 nullString
 unregisterTelephonyCallback void
 getServiceState null
 getVoiceMailNumber nullString
+getIccAuthentication nullString
 
 [com.android.internal.gmscompat.sysservice.GmcPackageManager]
 getPackagesForUid nullArray


### PR DESCRIPTION
Should fix the crash reported in:

- https://github.com/GrapheneOS/os-issue-tracker/issues/7854
- https://github.com/GrapheneOS/os-issue-tracker/issues/7708
- https://github.com/GrapheneOS/os-issue-tracker/issues/7794
- https://github.com/GrapheneOS/os-issue-tracker/issues/7875