### PR TITLE
Fix refcount race, flush() races, callerPkg spoofing

### DIFF
--- a/src/app/grapheneos/gmscompat/BinderGms2Gca.kt
+++ b/src/app/grapheneos/gmscompat/BinderGms2Gca.kt
@@ -54,6 +54,7 @@ object BinderGms2Gca : IGms2Gca.Stub() {
         Log.d(TAG, "connect from $pkg|$processName, pid ${boundProcess.pid}")
 
         val deathRecipient = DeathRecipient(iGca2Gms)
+        val persistentFgServiceLatch = PersistentFgService.requestStart()
         try {
             // important to add before linkToDeath() to avoid race with binderDied() callback
             addBoundProcess(iGca2Gms, boundProcess)
@@ -63,7 +64,6 @@ object BinderGms2Gca : IGms2Gca.Stub() {
             deathRecipient.binderDied()
             throw e
         }
-        val persistentFgServiceLatch = PersistentFgService.requestStart()
 
         // Config holder update event might be delivered after GMS process starts if both
         // GMS component and GmsCompatConfig holder are updated together, atomically.

--- a/src/app/grapheneos/gmscompat/BinderGms2Gca.kt
+++ b/src/app/grapheneos/gmscompat/BinderGms2Gca.kt
@@ -279,6 +279,7 @@ object BinderGms2Gca : IGms2Gca.Stub() {
     }
 
     override fun startActivityFromTheBackground(callerPkg: String, intent: PendingIntent) {
+        verifyCallerPkg(callerPkg)
         val ctx = App.ctx()
         Notifications.builder(Notifications.CH_BACKGROUND_ACTIVITY_START)
                 .setSmallIcon(R.drawable.ic_configuration_required)
@@ -522,6 +523,7 @@ object BinderGms2Gca : IGms2Gca.Stub() {
     val missingPostNotifsNotifIds = ArrayMap<String, Int>()
 
     override fun showMissingPostNotifsPermissionNotification(callerPkg: String) {
+        verifyCallerPkg(callerPkg)
         val notifId = synchronized(missingPostNotifsNotifIds) {
             missingPostNotifsNotifIds.getOrPut(callerPkg) {
                 Notifications.generateUniqueNotificationId()

--- a/src/app/grapheneos/gmscompat/location/OsLocationListener.kt
+++ b/src/app/grapheneos/gmscompat/location/OsLocationListener.kt
@@ -10,6 +10,7 @@ import com.google.android.gms.location.LocationAvailability
 import com.google.android.gms.location.LocationRequest
 import java.util.Collections
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import kotlin.math.max
 import kotlin.math.min
 
@@ -107,24 +108,30 @@ class OsLocationListener(val client: Client, val provider: OsLocationProvider,
         onLocationAvailabilityChanged(false)
     }
 
-    private var flushLatch: CountDownLatch? = null
+    private class FlushRequest(val code: Int, val latch: CountDownLatch)
+
+    @Volatile
+    private var activeFlush: FlushRequest? = null
+    private var flushRequestCode = 0
 
     fun flush() {
-        val l = CountDownLatch(1)
         synchronized(this) {
-            flushLatch = l
+            val f = FlushRequest(++flushRequestCode, CountDownLatch(1))
+            activeFlush = f
             try {
-                client.locationManager.requestFlush(provider.name, this, 0)
+                client.locationManager.requestFlush(provider.name, this, f.code)
+                if (!f.latch.await(5, TimeUnit.SECONDS)) {
+                    logd{"flush timed out"}
+                }
+            } catch (e: IllegalArgumentException) {
             } catch (e: IllegalStateException) {
-                // may get thrown if other thread unregisters this listener
-                return
+            } finally {
+                activeFlush = null
             }
-            l.await()
-            flushLatch = null
         }
     }
 
     override fun onFlushComplete(requestCode: Int) {
-        flushLatch!!.countDown()
+        activeFlush?.let { if (it.code == requestCode) it.latch.countDown() }
     }
 }


### PR DESCRIPTION
Proper #275. The reasoning for each change is in the commit bodies, with all framework behavior claims checked against the 16-qpr2 frameworks/base sources.