### PR TITLE
lib: increase log level of maybeInterceptBinderProxyDump()

### DIFF
--- a/lib/src/app/grapheneos/gmscompat/lib/GmsCompatLibImpl.java
+++ b/lib/src/app/grapheneos/gmscompat/lib/GmsCompatLibImpl.java
@@ -68,9 +68,7 @@ public class GmsCompatLibImpl implements IGmsCompatLib {
 
     @Override
     public boolean maybeInterceptBinderProxyDump(BinderProxy binderProxy, FileDescriptor fd, String[] args, boolean async) {
-        if (Log.isLoggable(TAG_BINDER, Log.DEBUG)) {
-            Log.d(TAG_BINDER, "maybeInterceptBinderProxyDump: " + BinderUtils.getInterfaceDescriptor(binderProxy) + " " + Arrays.toString(args), maybeStackTrace(TAG_BINDER));
-        }
+        Log.i(TAG_BINDER, "maybeInterceptBinderProxyDump: " + BinderUtils.getInterfaceDescriptor(binderProxy) + " " + Arrays.toString(args), maybeStackTrace(TAG_BINDER));
         return false;
     }
 


### PR DESCRIPTION
Droidguard dumps several binders as part of its integrity checks.