### PR TITLE
add recovery keystore permission UI + SetupDesign flow for Find Hub permissions

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -32,6 +32,8 @@ android_app {
         "SettingsLibCategory",
         "SettingsLibCollapsingToolbarBaseActivity",
         "SettingsLibFooterPreference",
+        "SettingsLibSettingsTheme",
+        "setupdesign",
     ],
     jarjar_rules: "jarjar-rules.txt",
 

--- a/Android.bp
+++ b/Android.bp
@@ -32,6 +32,7 @@ android_app {
         "SettingsLibCategory",
         "SettingsLibCollapsingToolbarBaseActivity",
         "SettingsLibFooterPreference",
+        "SettingsLibLayoutPreference",
         "SettingsLibSettingsTheme",
         "setupdesign",
     ],

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -101,6 +101,14 @@
             android:theme="@style/Theme.GmsCompat.SetupFlow" />
 
         <activity
+            android:name=".configui.gmscore.GmsCoreFindHubSetupActivity"
+            android:exported="false"
+            android:label="@string/find_hub_setup_title"
+            android:launchMode="singleTask"
+            android:taskAffinity="app.grapheneos.gmscompat.find_hub"
+            android:theme="@style/Theme.GmsCompat.SetupFlow" />
+
+        <activity
             android:name=".location.StubResolutionActivity"
             android:exported="true" />
 

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -93,6 +93,14 @@
         </activity>
 
         <activity
+            android:name=".configui.gmscore.GmsCoreRecoverableKeystoreActivity"
+            android:exported="false"
+            android:label="@string/gmscore_recover_keystore_access_title"
+            android:launchMode="singleTask"
+            android:taskAffinity="app.grapheneos.gmscompat.recoverable_keystore"
+            android:theme="@style/Theme.GmsCompat.SetupFlow" />
+
+        <activity
             android:name=".location.StubResolutionActivity"
             android:exported="true" />
 

--- a/gmscompat_config
+++ b/gmscompat_config
@@ -30,6 +30,11 @@ PromoFeature__enabled perms-none-of android.permission.ACCESS_COARSE_LOCATION fa
 # below for increased stability
 Passkeys__client_data_hash_override_for_security_keys true
 
+[com.google.android.gms.findmydevice]
+# Powered off finding requires BLUETOOTH_PRIVILEGED to access NearbyManager APIs.
+# Avoid showing a notification for unavailable Find Hub functionality.
+EnableFindMyDeviceModule__show_power_off_finder_notification false
+
 [com.google.android.gms.gestureexchange#com.google.android.gms]
 # Gesture Exchange requires privileged NFC, secure settings and process state
 # integration. Disable its master flag to make GmsCore disable every component

--- a/res/drawable/ic_bullet_point.xml
+++ b/res/drawable/ic_bullet_point.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?attr/colorControlNormal"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,8C9.79,8 8,9.79 8,12s1.79,4 4,4 4,-1.79 4,-4 -1.79,-4 -4,-4z" />
+</vector>

--- a/res/drawable/ic_permission_allowed.xml
+++ b/res/drawable/ic_permission_allowed.xml
@@ -1,0 +1,25 @@
+<!--
+     Copyright (C) 2024 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M424,664L706,382L650,326L424,552L310,438L254,494L424,664ZM480,880Q397,880 324,848.5Q251,817 197,763Q143,709 111.5,636Q80,563 80,480Q80,397 111.5,324Q143,251 197,197Q251,143 324,111.5Q397,80 480,80Q563,80 636,111.5Q709,143 763,197Q817,251 848.5,324Q880,397 880,480Q880,563 848.5,636Q817,709 763,763Q709,817 636,848.5Q563,880 480,880ZM480,800Q614,800 707,707Q800,614 800,480Q800,346 707,253Q614,160 480,160Q346,160 253,253Q160,346 160,480Q160,614 253,707Q346,800 480,800ZM480,480Q480,480 480,480Q480,480 480,480Q480,480 480,480Q480,480 480,480Q480,480 480,480Q480,480 480,480Z"/>
+</vector>

--- a/res/layout/setup_flow_activity.xml
+++ b/res/layout/setup_flow_activity.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.fragment.app.FragmentContainerView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/setup_flow_nav_host"
+    android:name="androidx.navigation.fragment.NavHostFragment"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:filterTouchesWhenObscured="true"
+    app:defaultNavHost="true" />

--- a/res/layout/setup_flow_preference.xml
+++ b/res/layout/setup_flow_preference.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.setupdesign.GlifPreferenceLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@android:id/list_container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:filterTouchesWhenObscured="true" />

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -7,6 +7,126 @@
     <string name="persistent_fg_service_notif">Sandboxed Google Play is running</string>
 
     <string name="usage_guide">Usage guide</string>
+    <string name="usage_guide_summary">Find Hub permissions, full usage guide</string>
+    <string name="read_full_usage_guide">Read full usage guide</string>
+    <string name="find_hub">Find Hub</string>
+    <string name="find_hub_usage_guide_summary">Review permissions for registering trackers, finding this phone, helping the Find Hub network and receiving unknown tracker alerts.</string>
+
+    <string name="find_hub_setup_title">Set up Find Hub</string>
+    <string name="find_hub_setup_intro_summary">Choose the Find Hub features you want Play services to use.</string>
+    <string name="find_hub_setup_helps_category">What this guide helps with</string>
+    <string name="find_hub_setup_enroll_title">Find this phone</string>
+    <string name="find_hub_setup_enroll_summary">Play services can report this phone’s location while it is online and broadcast a Bluetooth signal so other Android devices can help locate it when it has no internet connection.</string>
+    <string name="find_hub_setup_add_devices_title">Register a tracker</string>
+    <string name="find_hub_setup_add_devices_summary">Play services can pair a supported tracker tag and add it to Find Hub. Location is not needed to register it, but other Find Hub functionality is reduced without precise Location.</string>
+    <string name="find_hub_setup_help_network_title">Help find nearby devices</string>
+    <string name="find_hub_setup_help_network_summary">
+"With Nearby devices, this phone can detect other devices in the Find Hub network. With precise Location, Play services can securely report where they were found.
+
+When directed by the Find Hub service, this phone can also send a protected Bluetooth command to a nearby tracker tag. The tracker verifies the command, turns on unwanted tracking protection mode, and broadcasts a signal that nearby Android and iOS devices can recognize as possible unwanted tracking."
+    </string>
+    <string name="find_hub_setup_unknown_tracker_alerts_title">Receive unknown tracker alerts</string>
+    <string name="find_hub_setup_unknown_tracker_alerts_summary">Play services can check in the background for trackers that may be traveling with you. Automatic alerts are available only in the owner user.</string>
+    <string name="find_hub_setup_keep_in_mind_category">Keep in mind</string>
+    <string name="find_hub_setup_complete_with_google_title">Complete setup with Google</string>
+    <string name="find_hub_setup_complete_with_google_summary">
+"This guide only prepares permissions. Enrollment and pairing are completed in Find Hub and Fast Pair."
+    </string>
+
+    <string name="find_hub_required_permissions_title">Required permissions for Find Hub</string>
+    <string name="find_hub_required_permissions_summary">
+"Find Hub uses a Google account keychain to protect its keys.
+
+Recovery keystore access lets Play services set up or recover that keychain."
+    </string>
+    <string name="find_hub_recovery_keystore_on_summary">
+"On
+
+Play services can set up and recover its Find Hub account keychain."
+    </string>
+    <string name="find_hub_recovery_keystore_off_summary">
+"Off
+
+Recovery keystore access is required to continue."
+    </string>
+    <string name="find_hub_unknown_tracker_alerts_footer">Recovery keystore access is not needed for unknown tracker alerts. In the owner user, Play services needs Nearby devices and precise Location set to “Allow all the time” for background checks. Background checks also require Bluetooth and Location to be turned on. Network access helps identify supported tracker tags, and Play services notifications let it alert you.</string>
+
+    <string name="find_hub_additional_permissions_title">Additional permissions</string>
+    <string name="find_hub_additional_permissions_summary">
+"Allowing Play services to use Nearby devices and precise Location with “Allow all the time” is recommended. Find Hub functionality is reduced without them."
+    </string>
+    <string name="find_hub_permission_status_category">Permission status</string>
+    <string name="find_hub_permission_details_category">How permissions are used</string>
+    <string name="find_hub_why_register_title">Register a tracker without Location</string>
+    <string name="find_hub_why_register_summary">
+"Pairing a tracker tag and adding it to Find Hub requires Bluetooth to be on and Play services to have Nearby devices. Other Find Hub features still use precise Location."
+    </string>
+    <string name="find_hub_nearby_devices_title">Nearby devices</string>
+    <string name="find_hub_nearby_devices_summary">
+"Play services uses Nearby devices to pair supported tracker tags, broadcast a changing Bluetooth signal so this phone can be found without internet access, and scan for nearby Find Hub devices.
+
+With precise Location, it can report where those devices were found and help detect possible unwanted tracking.
+
+Sandboxed Google Play cannot find this phone after it is turned off or runs out of battery, and some tracker tags may not be supported yet."
+    </string>
+    <string name="find_hub_location_title">Location</string>
+    <string name="find_hub_location_status_title">Precise Location set to “Allow all the time”</string>
+    <string name="find_hub_location_summary">
+"Play services uses precise Location to report this phone’s online location and, with Nearby devices, where it detects other Find Hub devices. It also uses this information to decide whether an unknown tracker may be moving with you.
+
+Without precise Location, Android does not provide Find Hub Bluetooth scan results to Play services. “Allow all the time” is needed for background features."
+    </string>
+    <string name="find_hub_unknown_tracker_alerts_permissions_summary">
+"Play services checks in the background for trackers signalling that they are away from their owner and may be moving with you. It uses Nearby devices and precise Location set to “Allow all the time”.
+
+Background checks also require Bluetooth and Location to be turned on. Network access helps identify supported tracker tags, and Play services notifications show alerts. Automatic alerts are available only in the owner user."
+    </string>
+    <string name="find_hub_network_title">Network</string>
+    <string name="find_hub_recommended_permission_status_summary">
+"Recommended · %1$s
+%2$s"
+    </string>
+    <string name="find_hub_required_permission_status_summary">
+"Required · %1$s
+%2$s"
+    </string>
+    <string name="find_hub_permission_allowed">Allowed</string>
+    <string name="find_hub_permission_partly_allowed">Partly allowed</string>
+    <string name="find_hub_permission_not_allowed">Not allowed</string>
+    <string name="find_hub_nearby_devices_status_summary">Used to find nearby Find Hub devices and pair supported tracker tags.</string>
+    <string name="find_hub_location_status_summary">Used for Find Hub scans and location reports, automatic unknown tracker alerts, and telling your registered tracker it is back with you.</string>
+    <string name="find_hub_network_status_summary">Needed to complete Find Hub setup and use online Find Hub services.</string>
+    <string name="find_hub_open_play_services_app_info">Open Play services app info</string>
+    <string name="find_hub_open_play_services_app_info_summary">Choose which Find Hub permissions Play services can use. Play services notifications are also needed for unknown tracker alerts.</string>
+    <string name="find_hub_finish_setup_title">Continue with Find Hub</string>
+    <string name="find_hub_finish_setup_summary">Use Find Hub and Play services to finish setting up the features you want.</string>
+    <string name="find_hub_open_play_store_title">Open Find Hub in Play Store</string>
+    <string name="find_hub_open_play_store_summary">Install, update or open the Find Hub app.</string>
+    <string name="find_hub_finish_add_tracker_title">Add a tracker</string>
+    <string name="find_hub_finish_add_tracker_summary">
+"Adding a tracker tag from the Play services pairing screen requires Bluetooth to be on and Play services to have Nearby devices. Location is not needed to register it.
+
+Play services still needs precise Location set to “Allow all the time” to report where this phone detects Find Hub devices and tell a nearby tracker tag registered to your Google Account that it is back with you.
+
+If the pairing screen does not appear, it can be opened from the “Google Play services needs to show a screen. Tap to allow” notification."
+    </string>
+    <string name="find_hub_finish_tracker_state_title">Let your tracker know it’s back with you</string>
+    <string name="find_hub_finish_tracker_state_summary">
+"Find Hub controls when unwanted tracking protection mode is turned on for a tracker tag registered to your Google Account. It can direct a nearby device in the network to send a protected Bluetooth command that the tracker verifies before turning on the mode.
+
+While this mode is on, the tracker broadcasts a Bluetooth signal that nearby Android and iOS devices can detect. If another person’s device keeps detecting the tracker nearby, that person may receive an unwanted tracker alert.
+
+The tracker can also appear in a manual scan for unknown trackers. While the tracker remains in this mode and is nearby, a person who receives an alert or finds it in a manual scan can make it play a sound to help locate it.
+
+When that tracker tag is near this phone, Play services can scan for it in the background and tell it to turn this mode off. For this scan, Play services needs Nearby devices and precise Location set to “Allow all the time”, with Bluetooth and Location turned on."
+    </string>
+    <string name="find_hub_finish_settings_title">Find Hub settings</string>
+    <string name="find_hub_finish_settings_summary">You can manage Find Hub settings from Sandboxed Google Play › Google Settings.</string>
+    <string name="find_hub_next_button">Next</string>
+    <string name="find_hub_back_button">Back</string>
+    <string name="find_hub_cancel_button">Cancel</string>
+    <string name="find_hub_done_button">Done</string>
+
     <string name="play_services">Play services</string>
     <string name="play_services_special_permissions">Play services special permissions</string>
     <string name="play_services_special_permissions_summary">ICC authentication, RCS activation, recovery keystore access</string>
@@ -278,7 +398,7 @@ To recover this account keychain after reinstalling Play services or setting up 
     <string name="gmscore_recover_keystore_access_footer_title">Only enable recovery keystore access if you trust Play services and Google\'s recovery system</string>
     <string name="gmscore_recover_keystore_access_footer">Turning recovery keystore access off blocks future requests, but does not delete data already synchronized to Google.</string>
     <string name="notif_gmscore_missing_recoverable_keystore_access_perm">Play services may need recovery keystore access to create or use synchronized passkeys in Google Password Manager.</string>
-    <string name="notif_gmscore_missing_find_hub_account_keychain_perm">Find Hub may need Play services to have recovery keystore access to add supported devices and trackers to your Google Account.</string>
+    <string name="notif_gmscore_missing_find_hub_account_keychain_perm">Play services needs recovery keystore access to add supported devices and tracker tags to your Google Account in Find Hub. Open Find Hub permission setup to review this and related permissions.</string>
 
     <string name="rcs_potential_issues">Potential issues with RCS activation</string>
     <string name="rcs_issue_header">These are the minimum requirements for RCS activation:</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -9,7 +9,7 @@
     <string name="usage_guide">Usage guide</string>
     <string name="play_services">Play services</string>
     <string name="play_services_special_permissions">Play services special permissions</string>
-    <string name="play_services_special_permissions_summary">ICC authentication, RCS activation</string>
+    <string name="play_services_special_permissions_summary">ICC authentication, RCS activation, recovery keystore access</string>
     <string name="play_store">Play Store</string>
     <string name="android_auto">Android Auto</string>
 <!--    <string name="google_settings">Google services &amp; preferences</string>-->
@@ -210,6 +210,74 @@ The network permission will also be allowed, it’s needed for communication wit
 Some carriers require an entitlement check (GSMA TS.43 with EAP-AKA authentication) to verify your phone number and activate RCS in Google Messages. This permission allows Google Play services to use your SIM to complete the EAP-AKA challenge-response from the carrier's entitlement server.
 "
 </string>
+
+    <string name="gmscore_recover_keystore_access_title">Recovery keystore access</string>
+    <string name="gmscore_recover_keystore_access_summary">On. Your screen lock can help protect recovery of keys owned by Play services for Find Hub and Google Password Manager.</string>
+    <string name="gmscore_recover_keystore_access_none_summary">Off. Play services cannot set up or recover its Google account keychain.</string>
+    <string name="gmscore_recover_keystore_access_intro_summary">This permission lets Google Play services access the recovery keystore for its Google account keychain. The recovery keystore uses your screen lock as part of the encryption protecting that keychain.</string>
+    <string name="gmscore_recover_keystore_how_it_works_category">How it works</string>
+    <string name="gmscore_recover_keystore_keys_encrypted_title">Keys are encrypted on your device</string>
+    <string name="gmscore_recover_keystore_keys_encrypted_summary">An account keychain contains encryption keys owned by Play services and synchronized between your devices. The recovery keystore encrypts them with a separate recovery key.</string>
+    <string name="gmscore_recover_keystore_screen_lock_title">Your screen lock protects recovery</string>
+    <string name="gmscore_recover_keystore_screen_lock_summary">After Play services sets up recovery, the recovery keystore waits until you next enter your screen lock. It uses a key derived from a hash of your screen lock to encrypt the recovery key.</string>
+    <string name="gmscore_recover_keystore_public_key_title">A verified public key adds another layer</string>
+    <string name="gmscore_recover_keystore_public_key_summary">Play services downloads Google\'s signed list of Trusted Hardware Module public keys. The recovery keystore verifies the list, selects one and adds a second layer of encryption around the recovery key. Play services then uploads the encrypted account keychain, with the recovery key protected by both layers, to Google\'s Cloud Key Vault Service.</string>
+    <string name="gmscore_recover_keystore_thm_title">Trusted Hardware Modules limit recovery attempts</string>
+    <string name="gmscore_recover_keystore_thm_summary">The matching private key stays inside Google\'s Trusted Hardware Modules (THMs). During recovery, a THM opens the second layer and limits incorrect screen lock attempts. Reaching the limit makes the encrypted keychain permanently unrecoverable.</string>
+    <string name="gmscore_recover_keystore_google_features_category">How Google features use it</string>
+    <string name="gmscore_recover_keystore_find_hub_locations_title">Find Hub protects locations for devices and tracker tags</string>
+    <string name="gmscore_recover_keystore_find_hub_locations_summary">Find Hub uses account keychain keys for devices and supported tracker tags linked to your Google Account. When a phone in the Find Hub network detects a nearby item, it encrypts its location for the item\'s owner before upload. If the item belongs to you, Find Hub on your devices uses your account keychain to read the location report.</string>
+    <string name="gmscore_recover_keystore_passkeys_title">Google Password Manager protects synchronized passkeys</string>
+    <string name="gmscore_recover_keystore_passkeys_summary">Google Password Manager encrypts synchronized passkeys with account keychain keys. These keys may need recovery after clearing Play services storage, reinstalling it, or setting up your Google Account on another device or profile.</string>
+    <string name="gmscore_recover_keystore_google_access_category">What Google can access</string>
+    <string name="gmscore_recover_keystore_on_device_title">On your device</string>
+    <string name="gmscore_recover_keystore_on_device_summary">Play services can use the keys it owns and see feature data before encryption or after decryption, including Find Hub locations and synchronized passkeys. It cannot access keys owned by other apps.</string>
+    <string name="gmscore_recover_keystore_on_servers_title">On Google\'s servers</string>
+    <string name="gmscore_recover_keystore_on_servers_summary">Google receives the encrypted account keychain, encrypted feature data, and information needed to synchronize them. Google does not receive your current screen lock or the unencrypted recovery key when recovery is set up.</string>
+    <string name="gmscore_recover_keystore_during_recovery_title">During recovery</string>
+    <string name="gmscore_recover_keystore_during_recovery_summary">Clearing Play services storage, reinstalling it, or setting up your Google Account on another device or profile may start account keychain recovery. Play services may then show a recovery screen where you enter the screen lock that protected the keychain.</string>
+    <string name="gmscore_recover_keystore_keep_in_mind_category">Keep in mind</string>
+    <string name="gmscore_recover_keystore_clear_storage_title">Clearing storage removes local keys</string>
+    <string name="gmscore_recover_keystore_clear_storage_summary">On GrapheneOS, clearing Play services storage or uninstalling it removes local recovery data and related keys. Encrypted account keychain data already synchronized to Google remains available for recovery through Play services.</string>
+    <string name="gmscore_recover_keystore_access_dialog_title">Recovery keystore access</string>
+    <string name="gmscore_recover_keystore_access_dialog_message">
+"Allow Google Play services to access the recovery keystore for its account keychain?
+
+The recovery keystore uses your screen lock and Google\'s Trusted Hardware Modules to protect recovery of keys owned by Play services.
+
+To recover this account keychain after reinstalling Play services or setting up your Google Account on another device or profile, you will need to enter the screen lock that protected the keychain into Play services.
+"
+    </string>
+    <string name="gmscore_recover_keystore_restart_dialog_title">Restart required</string>
+    <string name="gmscore_recover_keystore_restart_dialog_message">A device restart is required for Play services to initialize account keychain recovery.</string>
+    <string name="gmscore_recover_keystore_restart_dialog_close">Close</string>
+    <string name="gmscore_recover_keystore_more_button">More</string>
+    <string name="gmscore_recover_keystore_dont_allow_button">Don\'t allow</string>
+    <string name="gmscore_recover_keystore_cancel_button">Cancel</string>
+    <string name="gmscore_recover_keystore_turn_off_button">Turn off access</string>
+    <string name="gmscore_recover_keystore_access_on_title">Recovery keystore access is on</string>
+    <string name="gmscore_recover_keystore_access_on_intro_summary">Play services can use the recovery keystore for its Google account keychain.</string>
+    <string name="gmscore_recover_keystore_what_access_does_category">What this access does</string>
+    <string name="gmscore_recover_keystore_protects_feature_keys_title">Protects keys used by Google features</string>
+    <string name="gmscore_recover_keystore_protects_feature_keys_summary">Play services\' account keychain contains encryption keys for Find Hub and synchronized passkeys in Google Password Manager. The recovery keystore encrypts the keys before Play services uploads the encrypted keychain to Google.</string>
+    <string name="gmscore_recover_keystore_uses_screen_lock_title">Uses your screen lock to protect recovery</string>
+    <string name="gmscore_recover_keystore_uses_screen_lock_summary">The recovery keystore uses your screen lock and a public key for Google\'s Trusted Hardware Modules as part of the encryption. Play services uploads only the encrypted result, not your current screen lock.</string>
+    <string name="gmscore_recover_keystore_if_turned_off_category">If you turn it off</string>
+    <string name="gmscore_recover_keystore_new_requests_blocked_title">New recovery keystore requests are blocked</string>
+    <string name="gmscore_recover_keystore_new_requests_blocked_summary">Play services can no longer set up or recover its account keychain. Find Hub may be unable to add supported devices or tracker tags to your Google Account, and Google Password Manager may be unable to create or use synchronized passkeys when recovery is needed.</string>
+    <string name="gmscore_recover_keystore_existing_data_not_deleted_title">Existing data is not deleted</string>
+    <string name="gmscore_recover_keystore_existing_data_not_deleted_summary">Turning off access does not delete local recovery data or encrypted account keychain data already synchronized to Google.</string>
+    <string name="gmscore_recover_keystore_can_turn_on_again_title">You can turn it on again</string>
+    <string name="gmscore_recover_keystore_can_turn_on_again_summary">After turning access on again, restart your device so Play services can initialize account keychain recovery.</string>
+    <string name="gmscore_recover_keystore_disable_dialog_title">Turn off recovery keystore access?</string>
+    <string name="gmscore_recover_keystore_disable_dialog_message">Turning this off blocks new recovery keystore requests. Find Hub and synchronized passkeys may stop working when account keychain recovery is needed. Existing local recovery data and data already synchronized to Google will remain.</string>
+    <string name="gmscore_recover_keystore_disable_dialog_button">Turn off</string>
+    <string name="gmscore_recover_keystore_more_info_category">More information</string>
+    <string name="gmscore_recover_keystore_whitepaper_title">Google Cloud Key Vault Service whitepaper</string>
+    <string name="gmscore_recover_keystore_whitepaper_summary">Learn more about account keychain recovery at &lt;a href=\'https://developer.android.com/about/versions/pie/security/ckv-whitepaper\'>developer.android.com/about/versions/pie/security/ckv-whitepaper&lt;/a>.</string>
+    <string name="gmscore_recover_keystore_access_footer_title">Only enable recovery keystore access if you trust Play services and Google\'s recovery system</string>
+    <string name="gmscore_recover_keystore_access_footer">Turning recovery keystore access off blocks future requests, but does not delete data already synchronized to Google.</string>
+    <string name="notif_gmscore_missing_recoverable_keystore_access_perm">Play services may need recovery keystore access to create or use synchronized passkeys in Google Password Manager.</string>
 
     <string name="rcs_potential_issues">Potential issues with RCS activation</string>
     <string name="rcs_issue_header">These are the minimum requirements for RCS activation:</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -278,6 +278,7 @@ To recover this account keychain after reinstalling Play services or setting up 
     <string name="gmscore_recover_keystore_access_footer_title">Only enable recovery keystore access if you trust Play services and Google\'s recovery system</string>
     <string name="gmscore_recover_keystore_access_footer">Turning recovery keystore access off blocks future requests, but does not delete data already synchronized to Google.</string>
     <string name="notif_gmscore_missing_recoverable_keystore_access_perm">Play services may need recovery keystore access to create or use synchronized passkeys in Google Password Manager.</string>
+    <string name="notif_gmscore_missing_find_hub_account_keychain_perm">Find Hub may need Play services to have recovery keystore access to add supported devices and trackers to your Google Account.</string>
 
     <string name="rcs_potential_issues">Potential issues with RCS activation</string>
     <string name="rcs_issue_header">These are the minimum requirements for RCS activation:</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -98,6 +98,14 @@ Background checks also require Bluetooth and Location to be turned on. Network a
     <string name="find_hub_network_status_summary">Needed to complete Find Hub setup and use online Find Hub services.</string>
     <string name="find_hub_open_play_services_app_info">Open Play services app info</string>
     <string name="find_hub_open_play_services_app_info_summary">Choose which Find Hub permissions Play services can use. Play services notifications are also needed for unknown tracker alerts.</string>
+    <string name="find_hub_bluetooth_off_warning_title">Bluetooth is off</string>
+    <string name="find_hub_bluetooth_off_warning_summary">Turn on Bluetooth to use Find Hub features that rely on nearby devices, including adding trackers and accessories.</string>
+    <string name="find_hub_bluetooth_auto_off_warning_title">Bluetooth may turn off automatically</string>
+    <string name="find_hub_bluetooth_auto_off_warning_summary">Bluetooth is set to turn off when no devices are connected. This can prevent this phone from being found through Find Hub or detecting nearby devices. Set “Turn off Bluetooth automatically” to “Never” in Settings.</string>
+    <string name="find_hub_bluetooth_auto_off_warning_secondary_user_summary">Bluetooth is set to turn off when no devices are connected. This can prevent this phone from being found through Find Hub or detecting nearby devices. Set “Turn off Bluetooth automatically” to “Never” in the owner user’s Settings.</string>
+    <string name="find_hub_check_settings_category">Check these settings</string>
+    <string name="find_hub_location_off_warning_title">Location is off</string>
+    <string name="find_hub_location_off_warning_summary">Turn on Location for location reports, background Find Hub scans, and finding a tracker tag registered to your Google Account while it signals that it is away from its owner.</string>
     <string name="find_hub_finish_setup_title">Continue with Find Hub</string>
     <string name="find_hub_finish_setup_summary">Use Find Hub and Play services to finish setting up the features you want.</string>
     <string name="find_hub_open_play_store_title">Open Find Hub in Play Store</string>

--- a/res/values/themes.xml
+++ b/res/values/themes.xml
@@ -27,6 +27,14 @@
         <item name="android:filterTouchesWhenObscured">true</item>
         <item name="android:windowActionBar">false</item>
         <item name="android:windowNoTitle">true</item>
+        <item name="preferenceTheme">@style/PreferenceTheme.SettingsLib.Expressive</item>
+        <item name="preferenceFragmentCompatStyle">
+            @style/GmsCompatSetupFlowPreferenceFragmentStyle
+        </item>
+    </style>
+
+    <style name="GmsCompatSetupFlowPreferenceFragmentStyle" parent="PreferenceFragment.Material">
+        <item name="android:layout">@layout/setup_flow_preference</item>
     </style>
 
     <style name="GmsCompatSetupFlowPreferenceThemeOverlay"

--- a/res/values/themes.xml
+++ b/res/values/themes.xml
@@ -22,4 +22,18 @@
     <style name="Theme.GmsCompat.Settings.FilterTouches">
         <item name="android:filterTouchesWhenObscured">true</item>
     </style>
+
+    <style name="Theme.GmsCompat.SetupFlow" parent="SudThemeGlifV4.DayNight">
+        <item name="android:filterTouchesWhenObscured">true</item>
+        <item name="android:windowActionBar">false</item>
+        <item name="android:windowNoTitle">true</item>
+    </style>
+
+    <style name="GmsCompatSetupFlowPreferenceThemeOverlay"
+        parent="PreferenceTheme.SettingsLib.Expressive">
+        <item name="preferenceTheme">@style/PreferenceTheme.SettingsLib.Expressive</item>
+        <item name="preferenceFragmentCompatStyle">
+            @style/GmsCompatSetupFlowPreferenceFragmentStyle
+        </item>
+    </style>
 </resources>

--- a/src/app/grapheneos/gmscompat/BaseGlifFragment.kt
+++ b/src/app/grapheneos/gmscompat/BaseGlifFragment.kt
@@ -6,8 +6,15 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.preference.PreferenceScreen
+import androidx.preference.PreferenceViewHolder
+import androidx.recyclerview.widget.RecyclerView
+import com.android.settingslib.widget.SettingsBasePreferenceFragment
+import com.android.settingslib.widget.SettingsPreferenceGroupAdapter
+import com.android.settingslib.widget.SettingsThemeHelper
 import com.google.android.setupcompat.template.FooterBarMixin
 import com.google.android.setupdesign.GlifLayout
+import com.google.android.setupdesign.GlifPreferenceLayout
 
 abstract class BaseGlifFragment : Fragment() {
 
@@ -33,4 +40,83 @@ abstract class BaseGlifFragment : Fragment() {
     }
 
     protected open fun onGlifViewCreated(layout: GlifLayout, savedInstanceState: Bundle?) {}
+}
+
+abstract class BaseGlifPreferenceFragment : SettingsBasePreferenceFragment() {
+
+    final override fun onCreateAdapter(
+        preferenceScreen: PreferenceScreen,
+    ): RecyclerView.Adapter<*> =
+        if (SettingsThemeHelper.isExpressiveTheme(requireContext())) {
+            SetupFlowPreferenceAdapter(preferenceScreen)
+        } else {
+            super.onCreateAdapter(preferenceScreen)
+        }
+
+    final override fun onCreateRecyclerView(
+        inflater: LayoutInflater,
+        parent: ViewGroup,
+        savedInstanceState: Bundle?,
+    ): RecyclerView {
+        val layout = parent as? GlifPreferenceLayout
+            ?: return super.onCreateRecyclerView(inflater, parent, savedInstanceState)
+        return layout.onCreateRecyclerView(inflater, parent, savedInstanceState)
+    }
+
+    final override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val layout = view as GlifPreferenceLayout
+        onGlifPreferenceViewCreated(layout, savedInstanceState)
+
+        // The Settings app's BiometricEnrollBase makes its footer opaque with the screen
+        // background.
+        val footerBackgroundColor = layout.footerBackgroundColor
+        val footerBar = layout.getMixin(FooterBarMixin::class.java)
+        footerBar.buttonContainer?.setBackgroundColor(footerBackgroundColor)
+    }
+
+    protected abstract fun onGlifPreferenceViewCreated(
+        layout: GlifPreferenceLayout,
+        savedInstanceState: Bundle?,
+    )
+}
+
+// Match Settings' PreferenceAdapterInSuw, which corrects the extra horizontal padding produced by
+// combining SetupDesign preference margins with SettingsLib's expressive preference backgrounds.
+private class SetupFlowPreferenceAdapter(
+    preferenceScreen: PreferenceScreen,
+) : SettingsPreferenceGroupAdapter(preferenceScreen) {
+    private val itemPaddingStart: Int
+    private val itemPaddingEnd: Int
+    private val contentPadding: Int
+
+    init {
+        val context = preferenceScreen.context
+        val attributes = context.obtainStyledAttributes(
+            intArrayOf(
+                android.R.attr.listPreferredItemPaddingStart,
+                android.R.attr.listPreferredItemPaddingEnd,
+            ),
+        )
+        itemPaddingStart = attributes.getDimensionPixelSize(0, 0)
+        itemPaddingEnd = attributes.getDimensionPixelSize(1, 0)
+        attributes.recycle()
+        contentPadding = context.resources.getDimensionPixelSize(
+            com.android.settingslib.widget.theme.R.dimen.settingslib_expressive_space_small1
+        )
+    }
+
+    override fun onBindViewHolder(holder: PreferenceViewHolder, position: Int) {
+        super.onBindViewHolder(holder, position)
+
+        val view = holder.itemView
+        val hasRoundedBackground = getRoundCornerDrawableRes(position, false) != 0
+        view.setPaddingRelative(
+            itemPaddingStart + if (hasRoundedBackground) contentPadding else 0,
+            view.paddingTop,
+            itemPaddingEnd + if (hasRoundedBackground) contentPadding else 0,
+            view.paddingBottom,
+        )
+    }
 }

--- a/src/app/grapheneos/gmscompat/BaseGlifFragment.kt
+++ b/src/app/grapheneos/gmscompat/BaseGlifFragment.kt
@@ -1,0 +1,36 @@
+package app.grapheneos.gmscompat
+
+import android.content.Context
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import com.google.android.setupcompat.template.FooterBarMixin
+import com.google.android.setupdesign.GlifLayout
+
+abstract class BaseGlifFragment : Fragment() {
+
+    protected abstract fun createGlifLayout(context: Context): GlifLayout
+
+    final override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View = createGlifLayout(inflater.context)
+
+    final override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val layout = view as GlifLayout
+        onGlifViewCreated(layout, savedInstanceState)
+
+        // The Settings app's BiometricEnrollBase makes its footer opaque with the screen
+        // background.
+        val footerBackgroundColor = layout.footerBackgroundColor
+        val footerBar = layout.getMixin(FooterBarMixin::class.java)
+        footerBar.buttonContainer?.setBackgroundColor(footerBackgroundColor)
+    }
+
+    protected open fun onGlifViewCreated(layout: GlifLayout, savedInstanceState: Bundle?) {}
+}

--- a/src/app/grapheneos/gmscompat/BaseSetupFlowActivity.kt
+++ b/src/app/grapheneos/gmscompat/BaseSetupFlowActivity.kt
@@ -1,0 +1,72 @@
+package app.grapheneos.gmscompat
+
+import android.content.res.Resources
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
+import androidx.navigation.NavController
+import androidx.navigation.NavGraph
+import androidx.navigation.fragment.NavHostFragment
+import androidx.navigation.fragment.findNavController
+import androidx.navigation.navOptions
+import com.android.settingslib.widget.ExpressiveDesignEnabledProvider
+import com.google.android.setupdesign.util.ThemeHelper
+
+abstract class BaseSetupFlowActivity : FragmentActivity(), ExpressiveDesignEnabledProvider {
+    protected abstract fun createNavigationGraph(controller: NavController): NavGraph
+
+    // SettingsBaseActivity uses this provider to let SettingsLib apply expressive preference
+    // grouping during SetupWizard flows.
+    final override fun isExpressiveDesignEnabled(): Boolean =
+        ThemeHelper.shouldApplyGlifExpressiveStyle(applicationContext)
+
+    protected override fun onApplyThemeResource(
+        theme: Resources.Theme,
+        resid: Int,
+        first: Boolean,
+    ) {
+        super.onApplyThemeResource(theme, resid, first)
+
+        // ThemeHelper replaces the manifest theme. Restore the SettingsLib preference styling
+        // after every SetupDesign theme selection.
+        theme.applyStyle(R.style.GmsCompatSetupFlowPreferenceThemeOverlay, true)
+    }
+
+    // Setup flows are the root of their own task and should not remain in Recents after exit.
+    final override fun finish() {
+        finishAndRemoveTask()
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        // Match the theme selection in the Settings app's BiometricEnrollBase.
+        ThemeHelper.trySetDynamicColor(this)
+        if (ThemeHelper.shouldApplyGlifExpressiveStyle(applicationContext)) {
+            ThemeHelper.trySetSuwTheme(this)
+        }
+
+        setContentView(R.layout.setup_flow_activity)
+
+        val navHost = supportFragmentManager.findFragmentById(R.id.setup_flow_nav_host)
+            as NavHostFragment
+        val controller = navHost.navController
+        controller.graph = createNavigationGraph(controller)
+    }
+}
+
+internal fun <T : Any> Fragment.navigateSetupFlow(route: T) {
+    findNavController().navigate(
+        route,
+        navOptions {
+            // Settings' FingerprintEnrollmentV2Activity uses these SetupDesign animations for
+            // fragment transitions. Their Android 12+ variants use SetupWizard's motion curve.
+            anim {
+                enter = com.google.android.setupdesign.R.anim.sud_slide_next_in
+                exit = com.google.android.setupdesign.R.anim.sud_slide_next_out
+                popEnter = com.google.android.setupdesign.R.anim.sud_slide_back_in
+                popExit = com.google.android.setupdesign.R.anim.sud_slide_back_out
+            }
+        },
+    )
+}

--- a/src/app/grapheneos/gmscompat/BaseSetupFlowActivity.kt
+++ b/src/app/grapheneos/gmscompat/BaseSetupFlowActivity.kt
@@ -15,10 +15,10 @@ import com.google.android.setupdesign.util.ThemeHelper
 abstract class BaseSetupFlowActivity : FragmentActivity(), ExpressiveDesignEnabledProvider {
     protected abstract fun createNavigationGraph(controller: NavController): NavGraph
 
-    // SettingsBaseActivity uses this provider to let SettingsLib apply expressive preference
-    // grouping during SetupWizard flows.
-    final override fun isExpressiveDesignEnabled(): Boolean =
-        ThemeHelper.shouldApplyGlifExpressiveStyle(applicationContext)
+    // These activities always use the expressive SettingsLib preference theme. Tell its
+    // preference adapter to add the rounded groups even when SetupWizard partner configuration is
+    // unavailable to this standalone flow.
+    final override fun isExpressiveDesignEnabled(): Boolean = true
 
     protected override fun onApplyThemeResource(
         theme: Resources.Theme,

--- a/src/app/grapheneos/gmscompat/BinderGms2Gca.kt
+++ b/src/app/grapheneos/gmscompat/BinderGms2Gca.kt
@@ -316,6 +316,10 @@ object BinderGms2Gca : IGms2Gca.Stub() {
         Notifications.handleGmsCoreMissingRecoverableKeystorePermission()
     }
 
+    override fun maybeShowGmsCoreMissingFindHubAccountKeychainPermissionNotification() {
+        Notifications.handleGmsCoreMissingFindHubAccountKeychainPermission()
+    }
+
     override fun maybeShowContactsSyncNotification() {
         Notifications.handleContactsSync()
     }

--- a/src/app/grapheneos/gmscompat/BinderGms2Gca.kt
+++ b/src/app/grapheneos/gmscompat/BinderGms2Gca.kt
@@ -312,6 +312,10 @@ object BinderGms2Gca : IGms2Gca.Stub() {
         ).show(Notifications.ID_GMS_CORE_MISSING_NEARBY_DEVICES_PERMISSION)
     }
 
+    override fun maybeShowGmsCoreMissingRecoverableKeystorePermissionNotification() {
+        Notifications.handleGmsCoreMissingRecoverableKeystorePermission()
+    }
+
     override fun maybeShowContactsSyncNotification() {
         Notifications.handleContactsSync()
     }

--- a/src/app/grapheneos/gmscompat/GlifPage.kt
+++ b/src/app/grapheneos/gmscompat/GlifPage.kt
@@ -1,0 +1,101 @@
+package app.grapheneos.gmscompat
+
+import android.content.Context
+import android.util.TypedValue
+import android.view.ViewGroup
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+import com.google.android.setupdesign.GlifLayout
+import com.google.android.setupdesign.view.BulletPointView
+import kotlin.math.roundToInt
+
+internal data class GlifPage(
+    @param:StringRes @field:StringRes val header: Int,
+    @param:StringRes @field:StringRes val description: Int,
+    val sections: List<GlifPageSection>,
+)
+
+internal data class GlifPageSection(
+    @param:StringRes @field:StringRes val title: Int,
+    val bullets: List<GlifPageBullet>,
+)
+
+internal data class GlifPageBullet(
+    @param:StringRes @field:StringRes val title: Int,
+    val summary: CharSequence,
+    @param:DrawableRes @field:DrawableRes val icon: Int,
+)
+
+internal fun renderGlifPage(context: Context, page: GlifPage): GlifLayout {
+    val layout =
+        GlifLayout(context).apply {
+            setHeaderText(page.header)
+            setDescriptionText(page.description)
+            filterTouchesWhenObscured = true
+            layoutParams =
+                ViewGroup.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                )
+        }
+
+    // Apply the same client styles as SetupDesign's XML examples.
+    val content =
+        LinearLayout(context, null, 0, com.google.android.setupdesign.R.style.SudContentFrame)
+            .apply {
+                orientation = LinearLayout.VERTICAL
+                layoutParams =
+                    ViewGroup.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT,
+                    )
+            }
+
+    page.sections.forEachIndexed { sectionIndex, section ->
+        content.addView(
+            TextView(context, null, com.google.android.setupdesign.R.attr.sudSectionItemTitleStyle)
+                .apply {
+                    setText(section.title)
+                    layoutParams =
+                        LinearLayout.LayoutParams(
+                                ViewGroup.LayoutParams.MATCH_PARENT,
+                                ViewGroup.LayoutParams.WRAP_CONTENT,
+                            )
+                            .apply {
+                                if (sectionIndex != 0) {
+                                    topMargin = context.dpToPx(24)
+                                }
+                                bottomMargin = context.dpToPx(8)
+                            }
+                }
+        )
+
+        section.bullets.forEach { bullet ->
+            content.addView(
+                BulletPointView(context).apply {
+                    setTitle(context.getText(bullet.title))
+                    setSummary(bullet.summary)
+                    setIcon(context.getDrawable(bullet.icon))
+                    layoutParams =
+                        LinearLayout.LayoutParams(
+                            ViewGroup.LayoutParams.MATCH_PARENT,
+                            ViewGroup.LayoutParams.WRAP_CONTENT,
+                        )
+                }
+            )
+        }
+    }
+
+    layout.addView(content)
+    return layout
+}
+
+private fun Context.dpToPx(value: Int): Int =
+    TypedValue.applyDimension(
+            TypedValue.COMPLEX_UNIT_DIP,
+            value.toFloat(),
+            resources.displayMetrics,
+        )
+        .roundToInt()

--- a/src/app/grapheneos/gmscompat/GmsCompatNavGraph.kt
+++ b/src/app/grapheneos/gmscompat/GmsCompatNavGraph.kt
@@ -7,6 +7,7 @@ import androidx.navigation.createGraph
 import androidx.navigation.fragment.fragment
 import app.grapheneos.gmscompat.configui.aauto.AndroidAutoConfigWrapperFragment
 import app.grapheneos.gmscompat.configui.gmscore.GmsCoreConfigWrapperFragment
+import app.grapheneos.gmscompat.configui.gmscore.GmsCoreFindHubSetupActivity
 import app.grapheneos.gmscompat.configui.gmscore.GmsCoreRecoverableKeystoreActivity
 
 object GmsCompatNavGraph {
@@ -19,6 +20,9 @@ object GmsCompatNavGraph {
             fragment<MainWrapperFragment, NavRoute.Main> {
                 label = ctx.getString(R.string.activity_name)
             }
+            fragment<UsageGuideWrapperFragment, NavRoute.UsageGuide> {
+                label = ctx.getString(R.string.usage_guide)
+            }
             fragment<AndroidAutoConfigWrapperFragment, NavRoute.AndroidAutoConfig> {
                 label = ctx.getString(R.string.android_auto)
             }
@@ -28,6 +32,10 @@ object GmsCompatNavGraph {
             activity<NavRoute.PlayServicesRecoverableKeystoreConfig> {
                 activityClass = GmsCoreRecoverableKeystoreActivity::class
                 label = ctx.getString(R.string.gmscore_recover_keystore_access_title)
+            }
+            activity<NavRoute.FindHubSetup> {
+                activityClass = GmsCoreFindHubSetupActivity::class
+                label = ctx.getString(R.string.find_hub_setup_title)
             }
         }
     }

--- a/src/app/grapheneos/gmscompat/GmsCompatNavGraph.kt
+++ b/src/app/grapheneos/gmscompat/GmsCompatNavGraph.kt
@@ -2,10 +2,12 @@ package app.grapheneos.gmscompat
 
 import androidx.navigation.NavController
 import androidx.navigation.NavGraph
+import androidx.navigation.activity
 import androidx.navigation.createGraph
 import androidx.navigation.fragment.fragment
 import app.grapheneos.gmscompat.configui.aauto.AndroidAutoConfigWrapperFragment
 import app.grapheneos.gmscompat.configui.gmscore.GmsCoreConfigWrapperFragment
+import app.grapheneos.gmscompat.configui.gmscore.GmsCoreRecoverableKeystoreActivity
 
 object GmsCompatNavGraph {
     fun create(
@@ -22,6 +24,10 @@ object GmsCompatNavGraph {
             }
             fragment<GmsCoreConfigWrapperFragment, NavRoute.PlayServicesConfig> {
                 label = ctx.getString(R.string.gmscore_settings)
+            }
+            activity<NavRoute.PlayServicesRecoverableKeystoreConfig> {
+                activityClass = GmsCoreRecoverableKeystoreActivity::class
+                label = ctx.getString(R.string.gmscore_recover_keystore_access_title)
             }
         }
     }

--- a/src/app/grapheneos/gmscompat/GmsCompatNavGraph.kt
+++ b/src/app/grapheneos/gmscompat/GmsCompatNavGraph.kt
@@ -8,9 +8,12 @@ import app.grapheneos.gmscompat.configui.aauto.AndroidAutoConfigWrapperFragment
 import app.grapheneos.gmscompat.configui.gmscore.GmsCoreConfigWrapperFragment
 
 object GmsCompatNavGraph {
-    fun create(controller: NavController): NavGraph {
+    fun create(
+        controller: NavController,
+        startDestination: NavRoute = NavRoute.Main,
+    ): NavGraph {
         val ctx = App.ctx()
-        return controller.createGraph(startDestination = NavRoute.Main) {
+        return controller.createGraph(startDestination = startDestination) {
             fragment<MainWrapperFragment, NavRoute.Main> {
                 label = ctx.getString(R.string.activity_name)
             }

--- a/src/app/grapheneos/gmscompat/MainActivity.kt
+++ b/src/app/grapheneos/gmscompat/MainActivity.kt
@@ -33,17 +33,9 @@ class MainActivity : SettingsTransitionActivity() {
         // This is for completeness purposes.
         super.onNewIntent(intent)
         setIntent(intent)
-        val navController = getNavController() ?: return
         val route = NavRoute.findRoute(intent.extras) ?: return
-        navController.apply {
-            val startRoute = graph.startDestinationRoute
-            if (startRoute != null) {
-                popBackStack(startRoute, inclusive = false)
-            } else {
-                popBackStack<NavRoute.Main>(inclusive = false)
-            }
-            navigateWithAnimation(route)
-        }
+        val navController = getNavController() ?: return
+        navController.graph = GmsCompatNavGraph.create(navController, route)
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -58,9 +50,16 @@ class MainActivity : SettingsTransitionActivity() {
             return
         }
 
+        val startDestination =
+            if (savedInstanceState == null && !intent.isLaunchedFromHistory) {
+                NavRoute.findRoute(intent.extras) ?: NavRoute.Main
+            } else {
+                NavRoute.Main
+            }
+
         val navController = getNavController()!!
         navController.apply {
-            graph = GmsCompatNavGraph.create(this)
+            graph = GmsCompatNavGraph.create(this, startDestination)
 
             /*
             Unfortunately, the following does not work, because collapsingtoolbar's action_bar is
@@ -74,12 +73,6 @@ class MainActivity : SettingsTransitionActivity() {
                 AppBarConfiguration(graph, null),
             )
             */
-        }
-
-        if (savedInstanceState == null && !intent.isLaunchedFromHistory) {
-            NavRoute.findRoute(intent.extras)?.let { route ->
-                navController.navigateWithAnimation(route)
-            }
         }
     }
 

--- a/src/app/grapheneos/gmscompat/MainFragment.kt
+++ b/src/app/grapheneos/gmscompat/MainFragment.kt
@@ -37,7 +37,11 @@ class MainFragment : SettingsBasePreferenceFragment() {
 
         screen.addPref().apply {
             title = getString(R.string.usage_guide)
-            intent = Intent(Intent.ACTION_VIEW, Uri.parse(USAGE_GUIDE_URL))
+            setSummary(R.string.usage_guide_summary)
+            setOnPreferenceClickListener {
+                navigateWithAnimation(NavRoute.UsageGuide)
+                true
+            }
         }
         screen.addPref().apply {
             title = getString(R.string.component_system_settings, getString(R.string.play_services))

--- a/src/app/grapheneos/gmscompat/NavRoute.kt
+++ b/src/app/grapheneos/gmscompat/NavRoute.kt
@@ -16,6 +16,12 @@ sealed class NavRoute {
     data object Main : NavRoute()
 
     @Serializable
+    data object UsageGuide : NavRoute()
+
+    @Serializable
+    data object FindHubSetup : NavRoute()
+
+    @Serializable
     data object AndroidAutoConfig : NavRoute() {
         const val basePath = "gmscompat://aautoconfig"
     }

--- a/src/app/grapheneos/gmscompat/NavRoute.kt
+++ b/src/app/grapheneos/gmscompat/NavRoute.kt
@@ -45,6 +45,9 @@ sealed class NavRoute {
         }
     }
 
+    @Serializable
+    data object PlayServicesRecoverableKeystoreConfig : NavRoute()
+
     companion object {
         private const val EXTRA_KEY_ROUTE = "gmscompat.route"
 

--- a/src/app/grapheneos/gmscompat/Notifications.kt
+++ b/src/app/grapheneos/gmscompat/Notifications.kt
@@ -16,6 +16,7 @@ import android.util.Log
 import app.grapheneos.gmscompat.App.MainProcessPrefs
 import app.grapheneos.gmscompat.configui.IssueCheck
 import app.grapheneos.gmscompat.configui.getAllIssueRes
+import app.grapheneos.gmscompat.configui.gmscore.GmsCoreRecoverableKeystoreActivity
 import app.grapheneos.gmscompat.configui.gmscore.rcsIssueChecks
 import com.android.internal.gmscompat.GmsInfo
 import java.util.concurrent.atomic.AtomicInteger
@@ -46,6 +47,7 @@ object Notifications {
     const val ID_MANAGE_PLAY_INTEGRITY_API = 12
     const val ID_ENABLE_GOOGLE_CREDENTIAL_PROVIDER = 13
     const val ID_MISSING_RCS_PERMISSIONS = 14
+    const val ID_GMS_CORE_MISSING_RECOVERABLE_KEYSTORE_PERMISSION = 16
 
     private val uniqueNotificationId = AtomicInteger(10_000)
     fun generateUniqueNotificationId() = uniqueNotificationId.getAndIncrement()
@@ -252,6 +254,26 @@ object Notifications {
             setAutoCancel(true)
             addAction(doNotShowAgainAction)
             show(id)
+        }
+    }
+
+    fun handleGmsCoreMissingRecoverableKeystorePermission() {
+        Log.d("GmsCompat/RecoverableKeystore", "missing recovery keystore access")
+
+        val ctx = App.ctx()
+        val intent = GmsCoreRecoverableKeystoreActivity.createIntent()
+
+        configurationRequired(
+            CH_MISSING_PERMISSION,
+            ctx.getText(R.string.missing_permission),
+            ctx.getText(
+                R.string.notif_gmscore_missing_recoverable_keystore_access_perm
+            ),
+            ctx.getText(R.string.open_settings),
+            intent,
+        ).apply {
+            setContentIntent(activityPendingIntent(intent))
+            show(ID_GMS_CORE_MISSING_RECOVERABLE_KEYSTORE_PERMISSION)
         }
     }
 

--- a/src/app/grapheneos/gmscompat/Notifications.kt
+++ b/src/app/grapheneos/gmscompat/Notifications.kt
@@ -260,15 +260,29 @@ object Notifications {
     fun handleGmsCoreMissingRecoverableKeystorePermission() {
         Log.d("GmsCompat/RecoverableKeystore", "missing recovery keystore access")
 
+        showGmsCoreMissingRecoverableKeystorePermission(
+            R.string.notif_gmscore_missing_recoverable_keystore_access_perm
+        )
+    }
+
+    fun handleGmsCoreMissingFindHubAccountKeychainPermission() {
+        Log.d("GmsCompat/RecoverableKeystore", "Find Hub needs recovery keystore access")
+
+        showGmsCoreMissingRecoverableKeystorePermission(
+            R.string.notif_gmscore_missing_find_hub_account_keychain_perm
+        )
+    }
+
+    private fun showGmsCoreMissingRecoverableKeystorePermission(
+        textResId: Int
+    ) {
         val ctx = App.ctx()
         val intent = GmsCoreRecoverableKeystoreActivity.createIntent()
 
         configurationRequired(
             CH_MISSING_PERMISSION,
             ctx.getText(R.string.missing_permission),
-            ctx.getText(
-                R.string.notif_gmscore_missing_recoverable_keystore_access_perm
-            ),
+            ctx.getText(textResId),
             ctx.getText(R.string.open_settings),
             intent,
         ).apply {

--- a/src/app/grapheneos/gmscompat/Notifications.kt
+++ b/src/app/grapheneos/gmscompat/Notifications.kt
@@ -16,6 +16,7 @@ import android.util.Log
 import app.grapheneos.gmscompat.App.MainProcessPrefs
 import app.grapheneos.gmscompat.configui.IssueCheck
 import app.grapheneos.gmscompat.configui.getAllIssueRes
+import app.grapheneos.gmscompat.configui.gmscore.GmsCoreFindHubSetupActivity
 import app.grapheneos.gmscompat.configui.gmscore.GmsCoreRecoverableKeystoreActivity
 import app.grapheneos.gmscompat.configui.gmscore.rcsIssueChecks
 import com.android.internal.gmscompat.GmsInfo
@@ -261,7 +262,9 @@ object Notifications {
         Log.d("GmsCompat/RecoverableKeystore", "missing recovery keystore access")
 
         showGmsCoreMissingRecoverableKeystorePermission(
-            R.string.notif_gmscore_missing_recoverable_keystore_access_perm
+            R.string.notif_gmscore_missing_recoverable_keystore_access_perm,
+            GmsCoreRecoverableKeystoreActivity.createIntent(),
+            R.string.open_settings,
         )
     }
 
@@ -269,21 +272,24 @@ object Notifications {
         Log.d("GmsCompat/RecoverableKeystore", "Find Hub needs recovery keystore access")
 
         showGmsCoreMissingRecoverableKeystorePermission(
-            R.string.notif_gmscore_missing_find_hub_account_keychain_perm
+            R.string.notif_gmscore_missing_find_hub_account_keychain_perm,
+            Intent(App.ctx(), GmsCoreFindHubSetupActivity::class.java),
+            R.string.find_hub_setup_title,
         )
     }
 
     private fun showGmsCoreMissingRecoverableKeystorePermission(
-        textResId: Int
+        textResId: Int,
+        intent: Intent,
+        resolutionTextResId: Int,
     ) {
         val ctx = App.ctx()
-        val intent = GmsCoreRecoverableKeystoreActivity.createIntent()
 
         configurationRequired(
             CH_MISSING_PERMISSION,
             ctx.getText(R.string.missing_permission),
             ctx.getText(textResId),
-            ctx.getText(R.string.open_settings),
+            ctx.getText(resolutionTextResId),
             intent,
         ).apply {
             setContentIntent(activityPendingIntent(intent))

--- a/src/app/grapheneos/gmscompat/UsageGuide.kt
+++ b/src/app/grapheneos/gmscompat/UsageGuide.kt
@@ -1,0 +1,50 @@
+package app.grapheneos.gmscompat
+
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import androidx.navigation.ActivityNavigator
+import androidx.navigation.fragment.findNavController
+import androidx.preference.Preference
+import com.android.settingslib.widget.SettingsBasePreferenceFragment
+
+class UsageGuideWrapperFragment : BaseCollapsingToolbarFragment() {
+    override fun createPreferenceFragment() = UsageGuideFragment()
+}
+
+class UsageGuideFragment : SettingsBasePreferenceFragment() {
+    override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+        val context = preferenceManager.context
+        val screen = preferenceManager.createPreferenceScreen(context)
+
+        screen.addPreference(
+            Preference(context).apply {
+                setTitle(R.string.read_full_usage_guide)
+                intent = Intent(Intent.ACTION_VIEW, Uri.parse(USAGE_GUIDE_URL))
+            }
+        )
+        screen.addPreference(
+            Preference(context).apply {
+                setTitle(R.string.find_hub)
+                setSummary(R.string.find_hub_usage_guide_summary)
+                isSingleLineTitle = false
+                setOnPreferenceClickListener {
+                    findNavController().navigate(
+                        NavRoute.FindHubSetup,
+                        null,
+                        ActivityNavigator.Extras.Builder()
+                            // Discard an interrupted guide flow so its separate task starts over.
+                            .addFlags(
+                                Intent.FLAG_ACTIVITY_NEW_TASK or
+                                    Intent.FLAG_ACTIVITY_CLEAR_TASK,
+                            )
+                            .build(),
+                    )
+                    true
+                }
+            }
+        )
+
+        preferenceScreen = screen
+    }
+}

--- a/src/app/grapheneos/gmscompat/configui/gmscore/GmsCoreConfig.kt
+++ b/src/app/grapheneos/gmscompat/configui/gmscore/GmsCoreConfig.kt
@@ -2,9 +2,12 @@ package app.grapheneos.gmscompat.configui.gmscore
 
 import android.Manifest
 import android.app.compat.gms.GmsCorePackageFlag
+import android.content.Intent
 import android.content.pm.ApplicationInfo
+import android.content.pm.GosPackageState
 import android.ext.PackageId
 import android.util.Log
+import androidx.navigation.ActivityNavigator
 import androidx.preference.Preference
 import androidx.preference.PreferenceScreen
 import androidx.navigation.fragment.findNavController
@@ -68,6 +71,7 @@ class GmsCoreConfigFragment : BaseGosConfigFragment(
 ) {
 
     lateinit var rcsPotentialIssues: Preference
+    lateinit var recoverableKeystorePref: Preference
 
     override fun configurePreferenceScreen(screen: PreferenceScreen) {
         screen.addPref(getText(R.string.gmscore_app_info_title)).apply {
@@ -81,6 +85,19 @@ class GmsCoreConfigFragment : BaseGosConfigFragment(
                 R.string.gmscore_icc_auth_perms_title,
                 R.string.gmscore_icc_auth_perms_confirm,
             )
+            recoverableKeystorePref =
+                addPref(getText(R.string.gmscore_recover_keystore_access_title)).apply {
+                    onPreferenceClickListener = Preference.OnPreferenceClickListener { _ ->
+                        findNavController().navigate(
+                            NavRoute.PlayServicesRecoverableKeystoreConfig,
+                            null,
+                            ActivityNavigator.Extras.Builder()
+                                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                                .build(),
+                        )
+                        true
+                    }
+                }
         }
 
         screen.addCategory(R.string.rcs_activation_category).apply {
@@ -110,5 +127,13 @@ class GmsCoreConfigFragment : BaseGosConfigFragment(
         )
 
         Notifications.unmarkRcsNotificationHandled()
+
+        val packageState = GosPackageState.get(CONFIG_PKG_NAME, requireContext().user)
+        recoverableKeystorePref.setSummary(when {
+            packageState.hasPackageFlag(
+                GmsCorePackageFlag.GRANT_PERMS_FOR_RECOVER_KEYSTORE_GMSCORE,
+            ) -> R.string.gmscore_recover_keystore_access_summary
+            else -> R.string.gmscore_recover_keystore_access_none_summary
+        })
     }
 }

--- a/src/app/grapheneos/gmscompat/configui/gmscore/GmsCoreFindHubSetup.kt
+++ b/src/app/grapheneos/gmscompat/configui/gmscore/GmsCoreFindHubSetup.kt
@@ -3,16 +3,22 @@ package app.grapheneos.gmscompat.configui.gmscore
 import android.Manifest
 import android.app.compat.gms.GmsCorePackageFlag
 import android.app.compat.gms.GmsUtils
+import android.bluetooth.BluetoothManager
 import android.content.Context
+import android.content.Intent
 import android.content.pm.GosPackageState
 import android.ext.PackageId
+import android.ext.settings.ExtSettings
+import android.location.LocationManager
 import android.os.Bundle
+import android.provider.Settings
 import android.view.ViewGroup
 import androidx.annotation.StringRes
 import androidx.navigation.NavController
 import androidx.navigation.createGraph
 import androidx.navigation.fragment.fragment
 import androidx.preference.Preference
+import androidx.preference.PreferenceCategory
 import androidx.preference.PreferenceGroup
 import app.grapheneos.gmscompat.APP_INFO_ITEM_PERMISSIONS
 import app.grapheneos.gmscompat.BaseGlifFragment
@@ -426,6 +432,11 @@ class GmsCoreFindHubAdditionalPermissionsFragment : BaseGlifPreferenceFragment()
 }
 
 class GmsCoreFindHubFinishSetupFragment : BaseGlifPreferenceFragment() {
+    private lateinit var warningsCategory: PreferenceCategory
+    private lateinit var bluetoothOffWarningPreference: Preference
+    private lateinit var bluetoothAutoOffWarningPreference: Preference
+    private lateinit var locationOffWarningPreference: Preference
+
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         val context = preferenceManager.context
         val screen = preferenceManager.createPreferenceScreen(context)
@@ -439,6 +450,43 @@ class GmsCoreFindHubFinishSetupFragment : BaseGlifPreferenceFragment() {
             }
         )
 
+        warningsCategory = PreferenceCategory(context).apply {
+            setTitle(R.string.find_hub_check_settings_category)
+            isVisible = false
+        }
+        screen.addPreference(warningsCategory)
+        bluetoothOffWarningPreference = Preference(context).apply {
+            setTitle(R.string.find_hub_bluetooth_off_warning_title)
+            setSummary(R.string.find_hub_bluetooth_off_warning_summary)
+            setIcon(R.drawable.ic_configuration_required)
+            intent = Intent(Settings.ACTION_BLUETOOTH_SETTINGS)
+            isVisible = false
+        }
+        warningsCategory.addPreference(bluetoothOffWarningPreference)
+
+        bluetoothAutoOffWarningPreference = Preference(context).apply {
+            setTitle(R.string.find_hub_bluetooth_auto_off_warning_title)
+            setSummary(
+                if (context.user.isSystem) {
+                    R.string.find_hub_bluetooth_auto_off_warning_summary
+                } else {
+                    R.string.find_hub_bluetooth_auto_off_warning_secondary_user_summary
+                }
+            )
+            setIcon(R.drawable.ic_configuration_required)
+            isSelectable = false
+            isVisible = false
+        }
+        warningsCategory.addPreference(bluetoothAutoOffWarningPreference)
+
+        locationOffWarningPreference = Preference(context).apply {
+            setTitle(R.string.find_hub_location_off_warning_title)
+            setSummary(R.string.find_hub_location_off_warning_summary)
+            setIcon(R.drawable.ic_configuration_required)
+            intent = Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS)
+            isVisible = false
+        }
+        warningsCategory.addPreference(locationOffWarningPreference)
         screen.addPreference(
             SetupDesignBulletPreference(
                 context,
@@ -460,6 +508,11 @@ class GmsCoreFindHubFinishSetupFragment : BaseGlifPreferenceFragment() {
         preferenceScreen = screen
     }
 
+    override fun onResume() {
+        super.onResume()
+        updateState()
+    }
+
     override fun onGlifPreferenceViewCreated(
         layout: GlifPreferenceLayout,
         savedInstanceState: Bundle?,
@@ -475,6 +528,28 @@ class GmsCoreFindHubFinishSetupFragment : BaseGlifPreferenceFragment() {
             FooterButton.ButtonType.CLEAR,
             { pressBack() },
         )
+        updateState()
+    }
+
+    private fun updateState() {
+        val context = requireContext()
+        val hasNearbyDevices = gmsCoreHasFindHubNearbyDevicesPermission()
+        val bluetoothAdapter = context.getSystemService(BluetoothManager::class.java)?.adapter
+        // GmsCore cannot scan in BLE-only mode while Bluetooth is off. That mode requires full
+        // BLUETOOTH_PRIVILEGED.
+        bluetoothOffWarningPreference.isVisible =
+            hasNearbyDevices && bluetoothAdapter != null && !bluetoothAdapter.isEnabled
+        bluetoothAutoOffWarningPreference.isVisible =
+            hasNearbyDevices && ExtSettings.BLUETOOTH_AUTO_OFF.get(context) != 0
+
+        val locationManager = context.getSystemService(LocationManager::class.java)
+        locationOffWarningPreference.isVisible =
+            locationManager?.isLocationEnabled == false
+
+        warningsCategory.isVisible =
+            bluetoothOffWarningPreference.isVisible ||
+                bluetoothAutoOffWarningPreference.isVisible ||
+                locationOffWarningPreference.isVisible
     }
 }
 

--- a/src/app/grapheneos/gmscompat/configui/gmscore/GmsCoreFindHubSetup.kt
+++ b/src/app/grapheneos/gmscompat/configui/gmscore/GmsCoreFindHubSetup.kt
@@ -1,0 +1,528 @@
+package app.grapheneos.gmscompat.configui.gmscore
+
+import android.Manifest
+import android.app.compat.gms.GmsCorePackageFlag
+import android.app.compat.gms.GmsUtils
+import android.content.Context
+import android.content.pm.GosPackageState
+import android.ext.PackageId
+import android.os.Bundle
+import android.view.ViewGroup
+import androidx.annotation.StringRes
+import androidx.navigation.NavController
+import androidx.navigation.createGraph
+import androidx.navigation.fragment.fragment
+import androidx.preference.Preference
+import androidx.preference.PreferenceGroup
+import app.grapheneos.gmscompat.APP_INFO_ITEM_PERMISSIONS
+import app.grapheneos.gmscompat.BaseGlifFragment
+import app.grapheneos.gmscompat.BaseGlifPreferenceFragment
+import app.grapheneos.gmscompat.BaseSetupFlowActivity
+import app.grapheneos.gmscompat.GlifPage
+import app.grapheneos.gmscompat.GlifPageBullet
+import app.grapheneos.gmscompat.GlifPageSection
+import app.grapheneos.gmscompat.R
+import app.grapheneos.gmscompat.appSettingsIntent
+import app.grapheneos.gmscompat.configui.addCategory
+import app.grapheneos.gmscompat.configui.createFooterPreference
+import app.grapheneos.gmscompat.gmsCoreHasPermission
+import app.grapheneos.gmscompat.navigateSetupFlow
+import app.grapheneos.gmscompat.pressBack
+import app.grapheneos.gmscompat.renderGlifPage
+import com.android.internal.gmscompat.GmsInfo.PACKAGE_GMS_CORE
+import com.android.settingslib.widget.LayoutPreference
+import com.google.android.setupcompat.template.FooterBarMixin
+import com.google.android.setupcompat.template.FooterButton
+import com.google.android.setupdesign.GlifLayout
+import com.google.android.setupdesign.GlifPreferenceLayout
+import com.google.android.setupdesign.view.BulletPointView
+import kotlinx.serialization.Serializable
+
+@Serializable
+private data object FindHubIntroductionScreen
+
+@Serializable
+private data object FindHubRequiredPermissionsScreen
+
+@Serializable
+private data object FindHubRecoverableKeystoreScreen
+
+@Serializable
+private data object FindHubAdditionalPermissionsScreen
+
+@Serializable
+private data object FindHubFinishSetupScreen
+
+private const val FIND_HUB_PACKAGE = "com.google.android.apps.adm"
+
+private val FIND_HUB_NEARBY_DEVICES_PERMISSIONS = arrayOf(
+    Manifest.permission.BLUETOOTH_SCAN,
+    Manifest.permission.BLUETOOTH_CONNECT,
+    Manifest.permission.BLUETOOTH_ADVERTISE,
+)
+
+private fun gmsCoreHasFindHubNearbyDevicesPermission(): Boolean =
+    FIND_HUB_NEARBY_DEVICES_PERMISSIONS.all(::gmsCoreHasPermission)
+
+class GmsCoreFindHubSetupActivity : BaseSetupFlowActivity() {
+    override fun createNavigationGraph(controller: NavController) =
+        controller.createGraph(startDestination = FindHubIntroductionScreen) {
+            fragment<GmsCoreFindHubIntroductionFragment, FindHubIntroductionScreen> {
+                label = getString(R.string.find_hub_setup_title)
+            }
+            fragment<GmsCoreFindHubRequiredPermissionsFragment, FindHubRequiredPermissionsScreen> {
+                label = getString(R.string.find_hub_required_permissions_title)
+            }
+            fragment<GmsCoreRecoverableKeystoreFragment, FindHubRecoverableKeystoreScreen> {
+                label = getString(R.string.gmscore_recover_keystore_access_title)
+            }
+            fragment<
+                GmsCoreFindHubAdditionalPermissionsFragment,
+                FindHubAdditionalPermissionsScreen,
+            > {
+                label = getString(R.string.find_hub_additional_permissions_title)
+            }
+            fragment<GmsCoreFindHubFinishSetupFragment, FindHubFinishSetupScreen> {
+                label = getString(R.string.find_hub_finish_setup_title)
+            }
+        }
+}
+
+class GmsCoreFindHubIntroductionFragment : BaseGlifFragment() {
+    override fun createGlifLayout(context: Context): GlifLayout =
+        renderGlifPage(
+            context,
+            GlifPage(
+                R.string.find_hub_setup_title,
+                R.string.find_hub_setup_intro_summary,
+                listOf(
+                    GlifPageSection(
+                        R.string.find_hub_setup_helps_category,
+                        listOf(
+                            bullet(
+                                R.string.find_hub_setup_enroll_title,
+                                R.string.find_hub_setup_enroll_summary,
+                            ),
+                            bullet(
+                                R.string.find_hub_setup_add_devices_title,
+                                R.string.find_hub_setup_add_devices_summary,
+                            ),
+                            bullet(
+                                R.string.find_hub_setup_help_network_title,
+                                R.string.find_hub_setup_help_network_summary,
+                            ),
+                            bullet(
+                                R.string.find_hub_setup_unknown_tracker_alerts_title,
+                                R.string.find_hub_setup_unknown_tracker_alerts_summary,
+                            ),
+                        ),
+                    ),
+                    GlifPageSection(
+                        R.string.find_hub_setup_keep_in_mind_category,
+                        listOf(
+                            bullet(
+                                R.string.find_hub_setup_complete_with_google_title,
+                                R.string.find_hub_setup_complete_with_google_summary,
+                            )
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+    override fun onGlifViewCreated(layout: GlifLayout, savedInstanceState: Bundle?) {
+        layout.setFindHubFooter(
+            R.string.find_hub_next_button,
+            FooterButton.ButtonType.NEXT,
+            { navigateSetupFlow(FindHubRequiredPermissionsScreen) },
+            R.string.find_hub_cancel_button,
+            FooterButton.ButtonType.CANCEL,
+            { requireActivity().finish() },
+        )
+    }
+
+    private fun bullet(@StringRes title: Int, @StringRes summary: Int) =
+        GlifPageBullet(title, getText(summary), R.drawable.ic_bullet_point)
+}
+
+class GmsCoreFindHubRequiredPermissionsFragment : BaseGlifPreferenceFragment() {
+    private lateinit var recoverableKeystorePreference: Preference
+    private lateinit var nextButton: FooterButton
+
+    override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+        val context = preferenceManager.context
+        val screen = preferenceManager.createPreferenceScreen(context)
+
+        recoverableKeystorePreference = Preference(context).apply {
+            setTitle(R.string.gmscore_recover_keystore_access_title)
+            isSingleLineTitle = false
+            setOnPreferenceClickListener {
+                navigateSetupFlow(FindHubRecoverableKeystoreScreen)
+                true
+            }
+        }
+        screen.addPreference(recoverableKeystorePreference)
+        screen.addPreference(createFooterPreference().apply {
+            setTitle(R.string.find_hub_unknown_tracker_alerts_footer)
+        })
+        preferenceScreen = screen
+    }
+
+    override fun onGlifPreferenceViewCreated(
+        layout: GlifPreferenceLayout,
+        savedInstanceState: Bundle?,
+    ) {
+        layout.setHeaderText(R.string.find_hub_required_permissions_title)
+        layout.setDescriptionText(R.string.find_hub_required_permissions_summary)
+        layout.setDividerInsets(Int.MAX_VALUE, 0)
+        nextButton = layout.setFindHubFooter(
+            R.string.find_hub_next_button,
+            FooterButton.ButtonType.NEXT,
+            {
+                if (updatePermissionState()) {
+                    navigateSetupFlow(FindHubAdditionalPermissionsScreen)
+                }
+            },
+            R.string.find_hub_back_button,
+            FooterButton.ButtonType.CLEAR,
+            { pressBack() },
+        )
+        updatePermissionState()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        updatePermissionState()
+    }
+
+    private fun updatePermissionState(): Boolean {
+        val enabled = hasRecoverableKeystoreAccess()
+        recoverableKeystorePreference.setSummary(
+            if (enabled) {
+                R.string.find_hub_recovery_keystore_on_summary
+            } else {
+                R.string.find_hub_recovery_keystore_off_summary
+            }
+        )
+        if (::nextButton.isInitialized) {
+            nextButton.isEnabled = enabled
+        }
+        return enabled
+    }
+
+    private fun hasRecoverableKeystoreAccess(): Boolean =
+        GosPackageState.get(
+            PackageId.GMS_CORE_NAME,
+            requireContext().user,
+        ).hasPackageFlag(
+            GmsCorePackageFlag.GRANT_PERMS_FOR_RECOVER_KEYSTORE_GMSCORE
+        )
+}
+
+class GmsCoreFindHubAdditionalPermissionsFragment : BaseGlifPreferenceFragment() {
+    private lateinit var nearbyDevicesPreference: Preference
+    private lateinit var locationPreference: Preference
+    private lateinit var networkPreference: Preference
+    private lateinit var nextButton: FooterButton
+
+    override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+        val context = preferenceManager.context
+        val screen = preferenceManager.createPreferenceScreen(context)
+
+        screen.addPreference(
+            Preference(context).apply {
+                setTitle(R.string.find_hub_open_play_services_app_info)
+                setSummary(R.string.find_hub_open_play_services_app_info_summary)
+                isSingleLineTitle = false
+                intent = appSettingsIntent(PACKAGE_GMS_CORE, APP_INFO_ITEM_PERMISSIONS)
+            }
+        )
+
+        val statusCategory = screen.addCategory(R.string.find_hub_permission_status_category)
+        nearbyDevicesPreference = statusCategory.addPermissionStatusPreference(
+            R.string.find_hub_nearby_devices_title
+        )
+        locationPreference = statusCategory.addPermissionStatusPreference(
+            R.string.find_hub_location_status_title
+        )
+        networkPreference = statusCategory.addPermissionStatusPreference(
+            R.string.find_hub_network_title
+        )
+
+        val detailsCategory = screen.addCategory(R.string.find_hub_permission_details_category)
+        detailsCategory.addPreference(
+            SetupDesignBulletPreference(
+                context,
+                R.string.find_hub_why_register_title,
+            ).apply {
+                setSummaryText(context.getText(R.string.find_hub_why_register_summary))
+            }
+        )
+        detailsCategory.addPreference(
+            SetupDesignBulletPreference(
+                context,
+                R.string.find_hub_finish_tracker_state_title,
+            ).apply {
+                // The Find Hub specification says its service can relay an activation request
+                // through the network. Play services automatically handles interaction
+                // instructions returned by SpotReportingService.UploadScans. The response
+                // provides a dedicated key used to authenticate the command, which the tracker
+                // verifies. The server's decision criteria are not exposed in the client:
+                // https://developers.google.com/nearby/fast-pair/specifications/extensions/fmdn#unwanted-tracking-prevention
+                //
+                // The cross-platform unwanted tracker specification permits another person to
+                // start a sound only while the tracker is separated from its owner. See section
+                // 3.13.4:
+                // https://www.ietf.org/archive/id/draft-ietf-dult-accessory-protocol-00.html#section-3.13.4
+                // Play services also limits manual scan results to separated trackers and
+                // rejects this action when its check finds the tracker back near its owner.
+                //
+                // On a user build, background scanning with Nearby devices allowed and precise
+                // Location set to “Allow all the time” produced these logs when Play services
+                // 26.24.34 (260400-938041327), version code 262434035, found a registered tracker
+                // back near its owner and turned the mode off:
+                //
+                //     I AdvertisedStateHandler: (REDACTED) Detected owned device with unwanted tracking protection mode: %s
+                //     I DeUnwantedTrackingIntOp: Deactivated unwanted tracking mode successfully.
+                setSummaryText(context.getText(R.string.find_hub_finish_tracker_state_summary))
+            }
+        )
+        detailsCategory.addPreference(
+            SetupDesignBulletPreference(
+                context,
+                R.string.find_hub_setup_unknown_tracker_alerts_title,
+            ).apply {
+                setSummaryText(
+                    context.getText(R.string.find_hub_unknown_tracker_alerts_permissions_summary)
+                )
+            }
+        )
+        detailsCategory.addPreference(
+            SetupDesignBulletPreference(
+                context,
+                R.string.find_hub_nearby_devices_title,
+            ).apply {
+                // GmsCore can remotely change the locator model list that does not skip Android
+                // bond creation through [com.google.android.gms.nearby]
+                // fast_pair_locator_tags_model_ids_to_bond. Keep the support warning independent
+                // of the installed GmsCore version. Do not describe Nearby devices as enabling
+                // powered-off finding: those NearbyManager APIs remain behind
+                // BLUETOOTH_PRIVILEGED, and the state query returns disabled when the GmsCompat
+                // permission fallback handles the denial.
+                setSummaryText(context.getText(R.string.find_hub_nearby_devices_summary))
+            }
+        )
+        detailsCategory.addPreference(
+            SetupDesignBulletPreference(
+                context,
+                R.string.find_hub_location_title,
+            ).apply {
+                setSummaryText(context.getText(R.string.find_hub_location_summary))
+            }
+        )
+        preferenceScreen = screen
+    }
+
+    override fun onGlifPreferenceViewCreated(
+        layout: GlifPreferenceLayout,
+        savedInstanceState: Bundle?,
+    ) {
+        layout.setHeaderText(R.string.find_hub_additional_permissions_title)
+        layout.setDescriptionText(R.string.find_hub_additional_permissions_summary)
+        layout.setDividerInsets(Int.MAX_VALUE, 0)
+        nextButton = layout.setFindHubFooter(
+            R.string.find_hub_next_button,
+            FooterButton.ButtonType.NEXT,
+            {
+                if (updatePermissionState()) {
+                    navigateSetupFlow(FindHubFinishSetupScreen)
+                }
+            },
+            R.string.find_hub_back_button,
+            FooterButton.ButtonType.CLEAR,
+            { pressBack() },
+        )
+        updatePermissionState()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        updatePermissionState()
+    }
+
+    private fun updatePermissionState(): Boolean {
+        nearbyDevicesPreference.updatePermissionStatus(
+            R.string.find_hub_recommended_permission_status_summary,
+            permissionStatus(*FIND_HUB_NEARBY_DEVICES_PERMISSIONS),
+            R.string.find_hub_nearby_devices_status_summary,
+        )
+        locationPreference.updatePermissionStatus(
+            R.string.find_hub_recommended_permission_status_summary,
+            permissionStatus(
+                Manifest.permission.ACCESS_FINE_LOCATION,
+                Manifest.permission.ACCESS_BACKGROUND_LOCATION,
+            ),
+            R.string.find_hub_location_status_summary,
+        )
+        val hasNetwork = gmsCoreHasPermission(Manifest.permission.INTERNET)
+        networkPreference.isVisible = !hasNetwork
+        if (!hasNetwork) {
+            networkPreference.updatePermissionStatus(
+                R.string.find_hub_required_permission_status_summary,
+                R.string.find_hub_permission_not_allowed,
+                R.string.find_hub_network_status_summary,
+            )
+        }
+        if (::nextButton.isInitialized) {
+            nextButton.isEnabled = hasNetwork
+        }
+        return hasNetwork
+    }
+
+    @StringRes
+    private fun permissionStatus(vararg permissions: String): Int {
+        val grantedCount = permissions.count(::gmsCoreHasPermission)
+        return when (grantedCount) {
+            permissions.size -> R.string.find_hub_permission_allowed
+            0 -> R.string.find_hub_permission_not_allowed
+            else -> R.string.find_hub_permission_partly_allowed
+        }
+    }
+
+    private fun permissionSummary(
+        @StringRes format: Int,
+        @StringRes status: Int,
+        @StringRes description: Int,
+    ): String =
+        getString(
+            format,
+            getString(status),
+            getString(description),
+        )
+
+    private fun Preference.updatePermissionStatus(
+        @StringRes format: Int,
+        @StringRes status: Int,
+        @StringRes consequence: Int,
+    ) {
+        summary = permissionSummary(format, status, consequence)
+        setIcon(
+            when (status) {
+                R.string.find_hub_permission_allowed -> R.drawable.ic_permission_allowed
+                R.string.find_hub_permission_partly_allowed -> R.drawable.ic_pending_action
+                else -> R.drawable.ic_configuration_required
+            }
+        )
+    }
+
+    private fun PreferenceGroup.addPermissionStatusPreference(
+        @StringRes title: Int,
+    ): Preference = Preference(context).also {
+        it.setTitle(title)
+        it.isSingleLineTitle = false
+        it.isSelectable = false
+        addPreference(it)
+    }
+}
+
+class GmsCoreFindHubFinishSetupFragment : BaseGlifPreferenceFragment() {
+    override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+        val context = preferenceManager.context
+        val screen = preferenceManager.createPreferenceScreen(context)
+
+        screen.addPreference(
+            Preference(context).apply {
+                setTitle(R.string.find_hub_open_play_store_title)
+                setSummary(R.string.find_hub_open_play_store_summary)
+                isSingleLineTitle = false
+                intent = GmsUtils.createAppPlayStoreIntent(FIND_HUB_PACKAGE)
+            }
+        )
+
+        screen.addPreference(
+            SetupDesignBulletPreference(
+                context,
+                R.string.find_hub_finish_add_tracker_title,
+            ).apply {
+                setSummaryText(context.getText(R.string.find_hub_finish_add_tracker_summary))
+            }
+        )
+
+        screen.addPreference(
+            SetupDesignBulletPreference(
+                context,
+                R.string.find_hub_finish_settings_title,
+            ).apply {
+                setSummaryText(context.getText(R.string.find_hub_finish_settings_summary))
+            }
+        )
+
+        preferenceScreen = screen
+    }
+
+    override fun onGlifPreferenceViewCreated(
+        layout: GlifPreferenceLayout,
+        savedInstanceState: Bundle?,
+    ) {
+        layout.setHeaderText(R.string.find_hub_finish_setup_title)
+        layout.setDescriptionText(R.string.find_hub_finish_setup_summary)
+        layout.setDividerInsets(Int.MAX_VALUE, 0)
+        layout.setFindHubFooter(
+            R.string.find_hub_done_button,
+            FooterButton.ButtonType.DONE,
+            { requireActivity().finish() },
+            R.string.find_hub_back_button,
+            FooterButton.ButtonType.CLEAR,
+            { pressBack() },
+        )
+    }
+}
+
+// Use the same SetupDesign view as the introduction page for bullets inside preference screens.
+private class SetupDesignBulletPreference private constructor(
+    context: Context,
+    private val bulletView: BulletPointView,
+) : LayoutPreference(context, bulletView) {
+    constructor(context: Context, @StringRes title: Int) : this(context, BulletPointView(context)) {
+        bulletView.setTitle(context.getText(title))
+        bulletView.setIcon(context.getDrawable(R.drawable.ic_bullet_point))
+        bulletView.layoutParams =
+            ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+            )
+        isSelectable = false
+    }
+
+    fun setSummaryText(summary: CharSequence) {
+        bulletView.setSummary(summary)
+    }
+}
+
+private fun GlifLayout.setFindHubFooter(
+    @StringRes primaryText: Int,
+    @FooterButton.ButtonType primaryType: Int,
+    onPrimaryClick: () -> Unit,
+    @StringRes secondaryText: Int,
+    @FooterButton.ButtonType secondaryType: Int,
+    onSecondaryClick: () -> Unit,
+): FooterButton {
+    val primaryButton = FooterButton.Builder(context)
+        .setText(primaryText)
+        .setListener { onPrimaryClick() }
+        .setButtonType(primaryType)
+        .setTheme(com.google.android.setupdesign.R.style.SudGlifButton_Primary)
+        .build()
+    val secondaryButton = FooterButton.Builder(context)
+        .setText(secondaryText)
+        .setListener { onSecondaryClick() }
+        .setButtonType(secondaryType)
+        .setTheme(com.google.android.setupdesign.R.style.SudGlifButton_Secondary)
+        .build()
+
+    getMixin(FooterBarMixin::class.java).apply {
+        this.primaryButton = primaryButton
+        this.secondaryButton = secondaryButton
+    }
+    return primaryButton
+}

--- a/src/app/grapheneos/gmscompat/configui/gmscore/GmsCoreRecoverableKeystoreConfig.kt
+++ b/src/app/grapheneos/gmscompat/configui/gmscore/GmsCoreRecoverableKeystoreConfig.kt
@@ -1,0 +1,303 @@
+package app.grapheneos.gmscompat.configui.gmscore
+
+import android.app.compat.gms.GmsCorePackageFlag
+import android.content.Context
+import android.content.Intent
+import android.content.pm.GosPackageState
+import android.ext.PackageId
+import android.os.Bundle
+import android.permission.PermissionManager
+import android.text.Html
+import androidx.annotation.StringRes
+import androidx.appcompat.app.AlertDialog
+import androidx.navigation.NavController
+import androidx.navigation.createGraph
+import androidx.navigation.fragment.fragment
+import app.grapheneos.gmscompat.App
+import app.grapheneos.gmscompat.BaseGlifFragment
+import app.grapheneos.gmscompat.BaseSetupFlowActivity
+import app.grapheneos.gmscompat.GlifPage
+import app.grapheneos.gmscompat.GlifPageBullet
+import app.grapheneos.gmscompat.GlifPageSection
+import app.grapheneos.gmscompat.Notifications
+import app.grapheneos.gmscompat.R
+import app.grapheneos.gmscompat.pressBack
+import app.grapheneos.gmscompat.renderGlifPage
+import com.google.android.setupcompat.template.FooterBarMixin
+import com.google.android.setupcompat.template.FooterButton
+import com.google.android.setupdesign.GlifLayout
+import com.google.android.setupdesign.template.RequireScrollMixin
+import kotlinx.serialization.Serializable
+
+@Serializable
+private data object RecoverableKeystoreScreen
+
+class GmsCoreRecoverableKeystoreActivity : BaseSetupFlowActivity() {
+    override fun createNavigationGraph(controller: NavController) =
+        controller.createGraph(startDestination = RecoverableKeystoreScreen) {
+            fragment<GmsCoreRecoverableKeystoreFragment, RecoverableKeystoreScreen> {
+                label = getString(
+                    R.string.gmscore_recover_keystore_access_title
+                )
+            }
+        }
+
+    companion object {
+        fun createIntent() = Intent(App.ctx(), GmsCoreRecoverableKeystoreActivity::class.java)
+    }
+}
+
+class GmsCoreRecoverableKeystoreFragment : BaseGlifFragment() {
+
+    // Keep the selected layout and its footer behavior on the same permission state snapshot.
+    private var recoverableKeystoreAccessEnabled = false
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        recoverableKeystoreAccessEnabled = GosPackageState.get(
+            PackageId.GMS_CORE_NAME,
+            requireContext().user,
+        ).hasPackageFlag(
+            GmsCorePackageFlag.GRANT_PERMS_FOR_RECOVER_KEYSTORE_GMSCORE
+        )
+    }
+
+    override fun createGlifLayout(context: Context): GlifLayout =
+        renderGlifPage(
+            context,
+            if (recoverableKeystoreAccessEnabled) createDisablePage() else createEnablePage(),
+        )
+
+    override fun onGlifViewCreated(layout: GlifLayout, savedInstanceState: Bundle?) {
+        val actionButton = FooterButton.Builder(layout.context)
+            .setText(
+                if (recoverableKeystoreAccessEnabled) {
+                    R.string.gmscore_recover_keystore_turn_off_button
+                } else {
+                    R.string.grant_dialog_button_allow
+                }
+            )
+            .setButtonType(
+                if (recoverableKeystoreAccessEnabled) {
+                    FooterButton.ButtonType.STOP
+                } else {
+                    FooterButton.ButtonType.OPT_IN
+                }
+            )
+            .setTheme(com.google.android.setupdesign.R.style.SudGlifButton_Primary)
+            .build()
+
+        val footerBar = layout.getMixin(FooterBarMixin::class.java)
+        footerBar.primaryButton = actionButton
+        footerBar.secondaryButton =
+            FooterButton.Builder(layout.context)
+                .setText(
+                    if (recoverableKeystoreAccessEnabled) {
+                        R.string.gmscore_recover_keystore_cancel_button
+                    } else {
+                        R.string.gmscore_recover_keystore_dont_allow_button
+                    }
+                )
+                .setListener { pressBack() }
+                .setButtonType(FooterButton.ButtonType.CANCEL)
+                .setTheme(com.google.android.setupdesign.R.style.SudGlifButton_Secondary)
+                .build()
+        layout.getMixin(RequireScrollMixin::class.java).requireScrollWithButton(
+            layout.context,
+            actionButton,
+            R.string.gmscore_recover_keystore_more_button,
+            {
+                if (recoverableKeystoreAccessEnabled) {
+                    showDisableAccessDialog()
+                } else {
+                    showEnableAccessDialog()
+                }
+            },
+        )
+    }
+
+    private fun createEnablePage() =
+        page(
+            R.string.gmscore_recover_keystore_access_title,
+            R.string.gmscore_recover_keystore_access_intro_summary,
+            section(
+                R.string.gmscore_recover_keystore_how_it_works_category,
+                bullet(
+                    R.string.gmscore_recover_keystore_keys_encrypted_title,
+                    R.string.gmscore_recover_keystore_keys_encrypted_summary,
+                ),
+                bullet(
+                    R.string.gmscore_recover_keystore_screen_lock_title,
+                    R.string.gmscore_recover_keystore_screen_lock_summary,
+                ),
+                bullet(
+                    R.string.gmscore_recover_keystore_public_key_title,
+                    R.string.gmscore_recover_keystore_public_key_summary,
+                ),
+                bullet(
+                    R.string.gmscore_recover_keystore_thm_title,
+                    R.string.gmscore_recover_keystore_thm_summary,
+                ),
+            ),
+            section(
+                R.string.gmscore_recover_keystore_google_features_category,
+                bullet(
+                    R.string.gmscore_recover_keystore_find_hub_locations_title,
+                    R.string.gmscore_recover_keystore_find_hub_locations_summary,
+                ),
+                bullet(
+                    R.string.gmscore_recover_keystore_passkeys_title,
+                    R.string.gmscore_recover_keystore_passkeys_summary,
+                ),
+            ),
+            section(
+                R.string.gmscore_recover_keystore_google_access_category,
+                bullet(
+                    R.string.gmscore_recover_keystore_on_device_title,
+                    R.string.gmscore_recover_keystore_on_device_summary,
+                ),
+                bullet(
+                    R.string.gmscore_recover_keystore_on_servers_title,
+                    R.string.gmscore_recover_keystore_on_servers_summary,
+                ),
+                bullet(
+                    R.string.gmscore_recover_keystore_during_recovery_title,
+                    R.string.gmscore_recover_keystore_during_recovery_summary,
+                ),
+            ),
+            section(
+                R.string.gmscore_recover_keystore_keep_in_mind_category,
+                bullet(
+                    R.string.gmscore_recover_keystore_clear_storage_title,
+                    R.string.gmscore_recover_keystore_clear_storage_summary,
+                ),
+            ),
+            section(
+                R.string.gmscore_recover_keystore_more_info_category,
+                whitepaperBullet(),
+                bullet(
+                    R.string.gmscore_recover_keystore_access_footer_title,
+                    R.string.gmscore_recover_keystore_access_footer,
+                ),
+            ),
+        )
+
+    private fun createDisablePage() =
+        page(
+            R.string.gmscore_recover_keystore_access_on_title,
+            R.string.gmscore_recover_keystore_access_on_intro_summary,
+            section(
+                R.string.gmscore_recover_keystore_what_access_does_category,
+                bullet(
+                    R.string.gmscore_recover_keystore_protects_feature_keys_title,
+                    R.string.gmscore_recover_keystore_protects_feature_keys_summary,
+                ),
+                bullet(
+                    R.string.gmscore_recover_keystore_uses_screen_lock_title,
+                    R.string.gmscore_recover_keystore_uses_screen_lock_summary,
+                ),
+                bullet(
+                    R.string.gmscore_recover_keystore_during_recovery_title,
+                    R.string.gmscore_recover_keystore_during_recovery_summary,
+                ),
+            ),
+            section(
+                R.string.gmscore_recover_keystore_if_turned_off_category,
+                bullet(
+                    R.string.gmscore_recover_keystore_new_requests_blocked_title,
+                    R.string.gmscore_recover_keystore_new_requests_blocked_summary,
+                ),
+                bullet(
+                    R.string.gmscore_recover_keystore_existing_data_not_deleted_title,
+                    R.string.gmscore_recover_keystore_existing_data_not_deleted_summary,
+                ),
+                bullet(
+                    R.string.gmscore_recover_keystore_can_turn_on_again_title,
+                    R.string.gmscore_recover_keystore_can_turn_on_again_summary,
+                ),
+            ),
+            section(R.string.gmscore_recover_keystore_more_info_category, whitepaperBullet()),
+        )
+
+    private fun page(
+        @StringRes header: Int,
+        @StringRes description: Int,
+        vararg sections: GlifPageSection,
+    ) = GlifPage(header, description, sections.asList())
+
+    private fun section(@StringRes title: Int, vararg bullets: GlifPageBullet) =
+        GlifPageSection(title, bullets.asList())
+
+    private fun bullet(@StringRes title: Int, @StringRes summary: Int) =
+        GlifPageBullet(title, getText(summary), R.drawable.ic_bullet_point)
+
+    private fun whitepaperBullet() =
+        GlifPageBullet(
+            R.string.gmscore_recover_keystore_whitepaper_title,
+            Html.fromHtml(
+                getString(R.string.gmscore_recover_keystore_whitepaper_summary),
+                Html.FROM_HTML_MODE_LEGACY,
+            ),
+            R.drawable.ic_info,
+        )
+
+    private fun showEnableAccessDialog() {
+        AlertDialog.Builder(requireContext()).run {
+            setTitle(R.string.gmscore_recover_keystore_access_dialog_title)
+            setMessage(R.string.gmscore_recover_keystore_access_dialog_message)
+            setPositiveButton(R.string.grant_dialog_button_allow) { _, _ ->
+                updateRecoverableKeystoreAccess(true)
+            }
+            setNegativeButton(android.R.string.cancel, null)
+            show()
+        }
+    }
+
+    private fun showDisableAccessDialog() {
+        AlertDialog.Builder(requireContext()).run {
+            setTitle(R.string.gmscore_recover_keystore_disable_dialog_title)
+            setMessage(R.string.gmscore_recover_keystore_disable_dialog_message)
+            setPositiveButton(R.string.gmscore_recover_keystore_disable_dialog_button) { _, _ ->
+                updateRecoverableKeystoreAccess(false)
+            }
+            setNegativeButton(android.R.string.cancel, null)
+            show()
+        }
+    }
+
+    private fun updateRecoverableKeystoreAccess(enabled: Boolean) {
+        val userId = android.os.Process.myUserHandle().identifier
+        val editor = GosPackageState.edit(PackageId.GMS_CORE_NAME, userId)
+        editor.setPackageFlagState(
+            GmsCorePackageFlag.GRANT_PERMS_FOR_RECOVER_KEYSTORE_GMSCORE,
+            enabled,
+        )
+        if (!editor.apply()) {
+            pressBack()
+            return
+        }
+
+        requireContext().getSystemService(PermissionManager::class.java)!!
+            .updatePermissionStateAndInvalidateCache(PackageId.GMS_CORE_NAME, userId)
+
+        if (enabled) {
+            Notifications.cancel(
+                Notifications.ID_GMS_CORE_MISSING_RECOVERABLE_KEYSTORE_PERMISSION
+            )
+            showRestartRequiredDialog()
+            return
+        }
+        pressBack()
+    }
+
+    private fun showRestartRequiredDialog() {
+        val dialog = AlertDialog.Builder(requireContext())
+            .setTitle(R.string.gmscore_recover_keystore_restart_dialog_title)
+            .setMessage(R.string.gmscore_recover_keystore_restart_dialog_message)
+            .setPositiveButton(R.string.gmscore_recover_keystore_restart_dialog_close, null)
+            .create()
+        dialog.setOnDismissListener { pressBack() }
+        dialog.show()
+    }
+}


### PR DESCRIPTION
Closes https://github.com/GrapheneOS/os-issue-tracker/issues/4079
Closes https://github.com/GrapheneOS/os-issue-tracker/issues/7972
Closes https://github.com/GrapheneOS/os-issue-tracker/issues/8381

Depends on https://github.com/GrapheneOS/platform_frameworks_base/pull/446

Recovery keystore permission is required to create non-hardware (not Yubikey, etc.), synchronized passkeys with Google Password Manager (https://github.com/GrapheneOS/os-issue-tracker/issues/8381). It's also required for registering a device on the Find Hub network (https://github.com/GrapheneOS/os-issue-tracker/issues/4079). When setting up Google account on another device or profile, the passkeys or Find Hub keys can be recovered with the user's screen lock from the original profile / device that protected them

- UI for recovery keystore permission. Recovery keystore usage is outlined in https://developer.android.com/about/versions/pie/security/ckv-whitepaper. When setting up Google account on another device / profile, user is required to enter the screen lock of the profile/device that the keys belong to into a WebView in Play services. 

  The framework could have been extended to allow the use a separate recovery PIN or password instead of the screen lock. However, Play services recovery pages refer to the recovery credential as a screen lock. Using a separate credential would therefore be confusing when restoring the account keychain on another device
  
  The UI will warn users that users will need to enter their screen lock into Play services in order to use/recover these keys on another device/profile. The justification in the whitepaper for this design of requiring screen lock to be entered into Play services seems to be:
  
  > This allows us to provide flexible UIs for entering the LSKF of another device -- the Framework of the current device might not have an appropriate UI for the entering the LSKF of the old device. 

- A SetupWizard-like UI to explain the permissions needed for Find Hub along with consequences of not allowing permissions. For example, Play services needs to have Nearby location and precise Location (allow all the time for background) permission + Bluetooth and Location on in order to scan for the user's registered trackers. 

  Scanning for the user's trackers is important, since tracker tags have an unwanted tracker protection mode that the Find Hub network can turn on for trackers. While a tracker is in this mode, other devices can pick up this in its unwanted tracker scans and do things such as play sound to locate it. Play services must be able to scan for the user's trackers in order to disable this mode when the user is nearby
  
Test: With recovery keystore permission granted, was able to use Google Password manager for passkeys on https://webauthn.io

Test: With recovery keystore permission granted, was able to register tracker tags (Pebblebee, UGREEN). Play services with Nearby devices and precise Location allowed all the time along with Bluetooth and Location on was able to deactivate unwanted tracker protection mode (`I DeUnwantedTrackingIntOp: Deactivated unwanted tracking mode successfully.`). Manual scans on other devices didn't show the trackers registered on GrapheneOS)

Test: Passkeys and Find Hub info was reusable on a different phone for the same Google account, after entering the original phone's screen lock into Play services' "Enter your screen lock for the selected device" UI:


<img width="40%" src="https://github.com/user-attachments/assets/2a18dc0a-ea3d-4d24-986b-77313fa391c4" />