### PR TITLE
Preserve host caller identity in Phenotype broker requests

### DIFF
--- a/lib/src/app/grapheneos/gmscompat/lib/GmsCompatLibImpl.java
+++ b/lib/src/app/grapheneos/gmscompat/lib/GmsCompatLibImpl.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.function.Function;
 
 import app.grapheneos.gmscompat.lib.playintegrity.PlayIntegrityUtils;
+import app.grapheneos.gmscompat.lib.providerinstaller.ProviderInstallerCompat;
 import app.grapheneos.gmscompat.lib.sysservice.SystemServiceOverridesRegistry;
 import app.grapheneos.gmscompat.lib.util.BinderUtils;
 
@@ -32,16 +33,22 @@ import app.grapheneos.gmscompat.lib.util.BinderUtils;
 public class GmsCompatLibImpl implements IGmsCompatLib {
     private static final String TAG = "GmcLib";
 
+    private Context hostContext;
+
     @Override
     public void init(Context appContext, Context libContext, String processName) {
         Log.d(TAG, "init: pkg: " + appContext.getPackageName() + ", process: " + processName);
+        hostContext = appContext;
         SystemServiceOverridesRegistry.init(appContext, binderProxyOverridesRegistry);
     }
 
     @Override
     public ServiceConnection maybeReplaceServiceConnection(Intent service, long flags, UserHandle user, ServiceConnection orig) {
         ServiceConnection override = PlayIntegrityUtils.maybeReplaceServiceConnection(service, orig);
-        return override;
+        if (override != null) {
+            return override;
+        }
+        return ProviderInstallerCompat.maybeWrap(hostContext, service, user, orig);
     }
 
     private static final String TAG_BINDER = "GmcLibBinder";

--- a/lib/src/app/grapheneos/gmscompat/lib/providerinstaller/PhenotypeRequest.java
+++ b/lib/src/app/grapheneos/gmscompat/lib/providerinstaller/PhenotypeRequest.java
@@ -1,0 +1,89 @@
+package app.grapheneos.gmscompat.lib.providerinstaller;
+
+import android.os.Parcel;
+
+/** Narrow GetServiceRequest rewrite; never changes Binder's authenticated caller. */
+public final class PhenotypeRequest {
+    public static final String DESCRIPTOR = "com.google.android.gms.common.internal.IGmsServiceBroker";
+    static final String GMS = "com.google.android.gms";
+
+    /** Returns an owned replacement, or null to forward the original unchanged. */
+    public static Parcel rewrite(Parcel data, String hostPackage) {
+        int saved = data.dataPosition();
+        Parcel out = null;
+        try {
+            data.setDataPosition(0);
+            data.enforceInterface(DESCRIPTOR);
+            data.readStrongBinder(); // callback: preserved by appendFrom, never marshalled
+            if (data.readInt() != 1) return null;
+            // Only support the extended SafeParcelable object header used by GetServiceRequest.
+            if (data.readInt() != 0xffff4f45) return null;
+            int sizeOffset = data.dataPosition();
+            int size = data.readInt();
+            int body = data.dataPosition();
+            if (size < 0 || size > data.dataSize() - body) return null;
+            int end = body + size;
+            int service = -1, fieldStart = -1, fieldEnd = -1;
+            boolean seenService = false;
+            while (data.dataPosition() < end) {
+                int start = data.dataPosition();
+                if (end - start < 4) return null;
+                int header = data.readInt();
+                int length = header >>> 16;
+                if (length == 0xffff) {
+                    if (end - data.dataPosition() < 4) return null;
+                    length = data.readInt();
+                }
+                int value = data.dataPosition();
+                if (length < 0 || length > end - value) return null;
+                int next = value + length;
+                switch (header & 0xffff) {
+                    case 2: // service ID
+                        if (seenService || length != 4) return null;
+                        seenService = true;
+                        service = data.readInt();
+                        break;
+                    case 4: // calling package
+                        if (fieldStart != -1 || length < 4) return null;
+                        String pkg = data.readString();
+                        if (data.dataPosition() != next || !GMS.equals(pkg)) return null;
+                        fieldStart = start;
+                        fieldEnd = next;
+                        break;
+                    default:
+                        break; // preserve unknown fields, including Binder objects, byte-for-byte
+                }
+                data.setDataPosition(next);
+            }
+            if (service != 51 || fieldStart < 0 || hostPackage == null
+                    || hostPackage.isEmpty() || GMS.equals(hostPackage)) return null;
+            out = Parcel.obtain();
+            out.appendFrom(data, 0, fieldStart);
+            out.setDataPosition(out.dataSize());
+            out.writeInt(0xffff0004);
+            int fieldSizeOffset = out.dataPosition();
+            out.writeInt(0);
+            int stringStart = out.dataPosition();
+            out.writeString(hostPackage);
+            int stringEnd = out.dataPosition();
+            out.setDataPosition(fieldSizeOffset);
+            out.writeInt(stringEnd - stringStart);
+            out.setDataPosition(stringEnd);
+            out.appendFrom(data, fieldEnd, data.dataSize() - fieldEnd);
+            int delta = out.dataSize() - data.dataSize();
+            out.setDataPosition(sizeOffset);
+            out.writeInt(size + delta);
+            out.setDataPosition(0);
+            Parcel result = out;
+            out = null;
+            return result;
+        } catch (RuntimeException malformed) {
+            return null;
+        } finally {
+            data.setDataPosition(saved);
+            if (out != null) out.recycle();
+        }
+    }
+
+    private PhenotypeRequest() {}
+}

--- a/lib/src/app/grapheneos/gmscompat/lib/providerinstaller/ProviderInstallerCompat.java
+++ b/lib/src/app/grapheneos/gmscompat/lib/providerinstaller/ProviderInstallerCompat.java
@@ -1,0 +1,48 @@
+package app.grapheneos.gmscompat.lib.providerinstaller;
+
+import android.content.Context;
+import android.content.Intent;
+import android.content.ServiceConnection;
+import android.os.BinderWrapper;
+import android.os.Parcel;
+import android.os.Process;
+import android.os.RemoteException;
+import android.os.UserHandle;
+
+import app.grapheneos.gmscompat.lib.util.ServiceConnectionWrapper;
+
+public final class ProviderInstallerCompat {
+    public static ServiceConnection maybeWrap(Context host, Intent intent, UserHandle user,
+            ServiceConnection original) {
+        if (host == null || host.getApplicationInfo().uid != Process.myUid()
+                || !Process.myUserHandle().equals(user)
+                || PhenotypeRequest.GMS.equals(host.getPackageName())
+                || !PhenotypeRequest.GMS.equals(intent.getPackage())
+                || !"com.google.android.gms.phenotype.service.START".equals(intent.getAction())) {
+            return null;
+        }
+        String hostPackage = host.getPackageName();
+        return new ServiceConnectionWrapper(original, binder -> {
+            try {
+                if (!PhenotypeRequest.DESCRIPTOR.equals(binder.getInterfaceDescriptor())) return null;
+            } catch (RemoteException e) {
+                return null;
+            }
+            return new BinderWrapper(binder) {
+                @Override
+                public boolean transact(int code, Parcel data, Parcel reply, int flags)
+                        throws RemoteException {
+                    Parcel replacement = code == 46 ? PhenotypeRequest.rewrite(data, hostPackage) : null;
+                    if (replacement == null) return super.transact(code, data, reply, flags);
+                    try {
+                        return super.transact(code, replacement, reply, flags);
+                    } finally {
+                        replacement.recycle();
+                    }
+                }
+            };
+        });
+    }
+
+    private ProviderInstallerCompat() {}
+}

--- a/lib/tests/providerinstaller/PhenotypeRequestTest.java
+++ b/lib/tests/providerinstaller/PhenotypeRequestTest.java
@@ -1,0 +1,65 @@
+package app.grapheneos.gmscompat.lib.providerinstaller;
+
+import android.os.Binder;
+import android.os.IBinder;
+import android.os.Parcel;
+
+/** Standalone device test: uses Android's real native Parcel and Binder implementation. */
+public final class PhenotypeRequestTest {
+    static int checks;
+    static void check(boolean value) { checks++; if (!value) throw new AssertionError("check " + checks); }
+    static Parcel request(int service, String pkg, boolean duplicate, IBinder callback, IBinder extra) {
+        Parcel p = Parcel.obtain();
+        p.writeInterfaceToken(PhenotypeRequest.DESCRIPTOR);
+        p.writeStrongBinder(callback);
+        p.writeInt(1);
+        p.writeInt(0xffff4f45);
+        int size = p.dataPosition(); p.writeInt(0);
+        int body = p.dataPosition();
+        p.writeInt(0x40002); p.writeInt(service);
+        string(p, pkg);
+        if (duplicate) string(p, pkg);
+        p.writeInt(0xffff0063);
+        int n = p.dataPosition(); p.writeInt(0);
+        int b = p.dataPosition(); p.writeStrongBinder(extra);
+        int e = p.dataPosition(); p.setDataPosition(n); p.writeInt(e-b); p.setDataPosition(e);
+        e = p.dataPosition(); p.setDataPosition(size); p.writeInt(e-body); p.setDataPosition(e);
+        p.writeInt(0x12345678); // trailing data must survive
+        return p;
+    }
+    static void string(Parcel p, String s) {
+        p.writeInt(0xffff0004); int n=p.dataPosition(); p.writeInt(0);
+        int b=p.dataPosition(); p.writeString(s); int e=p.dataPosition();
+        p.setDataPosition(n); p.writeInt(e-b); p.setDataPosition(e);
+    }
+    static void roundtrip(String host) {
+        Binder callback = new Binder(), extra = new Binder();
+        Parcel p=request(51, PhenotypeRequest.GMS, false, callback, extra);
+        int saved=p.dataPosition();
+        Parcel q=PhenotypeRequest.rewrite(p,host);
+        check(q!=null); check(p.dataPosition()==saved);
+        q.enforceInterface(PhenotypeRequest.DESCRIPTOR);
+        check(q.readStrongBinder()==callback); check(q.readInt()==1);
+        check(q.readInt()==0xffff4f45); int size=q.readInt(); int end=q.dataPosition()+size;
+        check(q.readInt()==0x40002); check(q.readInt()==51);
+        check(q.readInt()==0xffff0004); int length=q.readInt(); int b=q.dataPosition();
+        check(host.equals(q.readString())); check(q.dataPosition()==b+length);
+        check(q.readInt()==0xffff0063); q.readInt(); check(q.readStrongBinder()==extra);
+        check(q.dataPosition()==end); check(q.readInt()==0x12345678); check(q.dataAvail()==0);
+        q.recycle(); p.recycle();
+    }
+    public static void main(String[] args) {
+        roundtrip("com.google.android.apps.walletnfcrel"); roundtrip("a.b");
+        Parcel[] rejected={request(79,PhenotypeRequest.GMS,false,null,null),
+            request(51,"already.correct",false,null,null),
+            request(51,PhenotypeRequest.GMS,true,null,null),Parcel.obtain()};
+        for(Parcel p:rejected) {int pos=p.dataPosition(); check(PhenotypeRequest.rewrite(p,"host")==null); check(p.dataPosition()==pos); p.recycle();}
+        Parcel p=request(51,PhenotypeRequest.GMS,false,null,null);
+        check(PhenotypeRequest.rewrite(p,PhenotypeRequest.GMS)==null);
+        check(PhenotypeRequest.rewrite(p,null)==null);
+        p.setDataPosition(0); p.enforceInterface(PhenotypeRequest.DESCRIPTOR); p.readStrongBinder(); p.readInt(); p.readInt();
+        p.writeInt(Integer.MAX_VALUE);
+        check(PhenotypeRequest.rewrite(p,"host")==null); p.recycle();
+        System.out.println("PASS: " + checks + " assertions (native Android Parcel/Binder)");
+    }
+}

--- a/lib/tests/providerinstaller/ProviderInstallerCompatTest.java
+++ b/lib/tests/providerinstaller/ProviderInstallerCompatTest.java
@@ -1,0 +1,59 @@
+package app.grapheneos.gmscompat.lib.providerinstaller;
+
+import android.content.*;
+import android.content.pm.ApplicationInfo;
+import android.os.*;
+import android.os.Process;
+
+public final class ProviderInstallerCompatTest {
+    static final String HOST="com.google.android.apps.walletnfcrel";
+    static class Host extends ContextWrapper {
+        String pkg=HOST; int uid=Process.myUid();
+        Host() { super(null); }
+        public String getPackageName() { return pkg; }
+        public ApplicationInfo getApplicationInfo() { ApplicationInfo a=new ApplicationInfo(); a.uid=uid; return a; }
+    }
+    static class Connection implements ServiceConnection {
+        IBinder binder; int disconnected, died, empty;
+        public void onServiceConnected(ComponentName n, IBinder b) { binder=b; }
+        public void onServiceDisconnected(ComponentName n) { disconnected++; }
+        public void onBindingDied(ComponentName n) { died++; }
+        public void onNullBinding(ComponentName n) { empty++; }
+    }
+    static void check(boolean b) { PhenotypeRequestTest.check(b); }
+    public static void main(String[] args) throws Exception {
+        PhenotypeRequestTest.main(args);
+        Host host=new Host(); Connection c=new Connection();
+        Intent intent=new Intent("com.google.android.gms.phenotype.service.START").setPackage(PhenotypeRequest.GMS);
+        ServiceConnection w=ProviderInstallerCompat.maybeWrap(host,intent,Process.myUserHandle(),c);
+        check(w!=null);
+        ComponentName name=new ComponentName(PhenotypeRequest.GMS,"Test");
+        Binder base=new Binder() {
+            { attachInterface(null,PhenotypeRequest.DESCRIPTOR); }
+            protected boolean onTransact(int code, Parcel p, Parcel reply, int flags) {
+                if(code!=46) { check(code==47); return true; }
+                p.enforceInterface(PhenotypeRequest.DESCRIPTOR); p.readStrongBinder(); p.readInt();
+                p.readInt(); p.readInt(); p.readInt(); int service=p.readInt();
+                p.readInt(); p.readInt(); String pkg=p.readString();
+                check((service==51 ? HOST : PhenotypeRequest.GMS).equals(pkg));
+                reply.writeNoException(); return true;
+            }
+        };
+        w.onServiceConnected(name,base); check(c.binder!=base);
+        for(int service:new int[]{51,79}) {
+            Parcel p=PhenotypeRequestTest.request(service,PhenotypeRequest.GMS,false,null,null),r=Parcel.obtain();
+            check(c.binder.transact(46,p,r,0)); r.readException(); p.recycle(); r.recycle();
+        }
+        Parcel p=Parcel.obtain(); check(c.binder.transact(47,p,null,0)); p.recycle();
+        w.onServiceDisconnected(name); w.onBindingDied(name); w.onNullBinding(name);
+        check(c.disconnected==1 && c.died==1 && c.empty==1);
+        Binder wrong=new Binder(); w.onServiceConnected(name,wrong); check(c.binder==wrong);
+        host.uid++; check(ProviderInstallerCompat.maybeWrap(host,intent,Process.myUserHandle(),c)==null); host.uid--;
+        host.pkg=PhenotypeRequest.GMS; check(ProviderInstallerCompat.maybeWrap(host,intent,Process.myUserHandle(),c)==null); host.pkg=HOST;
+        check(ProviderInstallerCompat.maybeWrap(host,intent,null,c)==null);
+        intent.setAction("unrelated"); check(ProviderInstallerCompat.maybeWrap(host,intent,Process.myUserHandle(),c)==null);
+        intent.setAction("com.google.android.gms.phenotype.service.START").setPackage("other");
+        check(ProviderInstallerCompat.maybeWrap(host,intent,Process.myUserHandle(),c)==null);
+        System.out.println("PASS: " + PhenotypeRequestTest.checks + " total assertions, real platform BinderWrapper");
+    }
+}

--- a/lib/tests/providerinstaller/README.md
+++ b/lib/tests/providerinstaller/README.md
@@ -1,0 +1,60 @@
+# ProviderInstaller caller identity compatibility patch
+
+Source baseline: GrapheneOS/platform_packages_apps_GmsCompat at
+3fadfe0ec4c45a85186d623274eea83130fc1575 (GmsCompatLib manifest version 102).
+The installed VoltageOS framework and library were inspected; this is an upstream
+source patch, not a verified match to the complete VoltageOS source revision.
+
+Wallet 26.33.969972112 falls back from a missing ProviderInstaller Dynamite module
+to a GMS package context. With Play services 26.29.32 that context is subsequently
+used for Phenotype configuration registration from Wallet's UID. The service
+broker rejects the GMS package / Wallet UID pair.
+
+This patch adds a client connection wrapper for the explicit GMS Phenotype START
+action. It only rewrites transaction 46, service ID 51, and a calling-package field
+that says com.google.android.gms, using the host context captured at library init.
+It excludes GMS itself, contexts with a different UID, and cross-user bindings.
+The remote broker still validates the real Binder caller; no UID or attestation
+result is forged and no permission check is removed.
+
+The Parcel rewrite preserves callbacks, unknown fields, trailing data, flags,
+reply handling, and the caller's input position. Unknown/malformed requests pass
+through. Resolved intents lacking the explicit package/action are intentionally
+not handled in this first patch; live binding coverage must be checked on rollout.
+
+## Validation
+
+Run with a connected, explicitly selected device:
+
+```
+python3 lib/tests/providerinstaller/run-device-tests.py SERIAL /opt/android-sdk
+```
+
+Requirements: Java 17+, Android SDK platform 36 and build-tools 37.0.0, adb.
+Tests compile against SDK signatures plus a compile-only hidden API stub. The
+stub is excluded from the dex; app_process uses the device's real BinderWrapper,
+Parcel and Binder. Tests only write a standalone dex to /data/local/tmp.
+
+On a Xiaomi apollo running a modified VoltageOS Android 17 build, the suite passed 56 assertions, including
+shorter/longer replacement strings, Binder references, unknown/trailing fields,
+wrong services, already-correct identities, duplicate/malformed fields, input
+position preservation, connection lifecycle forwarding and the real wrapper's
+transaction/reply path. This is local Binder testing, not cross-process Binder
+or Wallet end-to-end verification.
+
+## Build and rollout boundary
+
+In the matching ROM platform checkout, apply this patch under packages/apps/GmsCompat
+and build `m GmsCompatLib`. The module needs platform APIs and the configured
+`gmscompat_lib` certificate. The full Soong build was not available in this checkout.
+Do not assume an arbitrary locally signed APK can replace the trusted library.
+
+This was not reproduced on an unmodified GrapheneOS installation. Enabled app
+hooks and the downstream ROM remain possible contributors to the observed issue.
+The patch is a proposed compatibility workaround, not a proven upstream regression fix.
+
+The next device test is a properly built/signed library, followed by Wallet
+ProviderInstaller startup, confirming the Phenotype binding passes through this
+wrapper and the package-identity error disappears. Wallet payment eligibility and
+attestation are separate tests. No production library, app settings, modules or
+Wallet data have been changed by preparing this patch.

--- a/lib/tests/providerinstaller/compile-only/android/os/BinderWrapper.java
+++ b/lib/tests/providerinstaller/compile-only/android/os/BinderWrapper.java
@@ -1,0 +1,15 @@
+package android.os;
+
+/** Compile-only platform API signature. Never included in the test dex. */
+public class BinderWrapper implements IBinder {
+    public BinderWrapper(IBinder base) { throw new AssertionError(); }
+    public boolean transact(int code, Parcel data, Parcel reply, int flags) throws RemoteException { throw new AssertionError(); }
+    public String getInterfaceDescriptor() throws RemoteException { throw new AssertionError(); }
+    public boolean pingBinder() { throw new AssertionError(); }
+    public boolean isBinderAlive() { throw new AssertionError(); }
+    public IInterface queryLocalInterface(String s) { throw new AssertionError(); }
+    public void dump(java.io.FileDescriptor fd, String[] args) throws RemoteException { throw new AssertionError(); }
+    public void dumpAsync(java.io.FileDescriptor fd, String[] args) throws RemoteException { throw new AssertionError(); }
+    public void linkToDeath(DeathRecipient r, int flags) throws RemoteException { throw new AssertionError(); }
+    public boolean unlinkToDeath(DeathRecipient r, int flags) { throw new AssertionError(); }
+}

--- a/lib/tests/providerinstaller/run-device-tests.py
+++ b/lib/tests/providerinstaller/run-device-tests.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Compile isolated tests and run with the device's real Android framework.
+Usage: run-device-tests.py SERIAL SDK_ROOT
+Does not install or modify GmsCompat/Wallet. Leaves one dex in /data/local/tmp.
+"""
+import pathlib
+import subprocess
+import sys
+import tempfile
+
+serial, sdk_arg = sys.argv[1:]
+sdk = pathlib.Path(sdk_arg)
+repo = pathlib.Path(__file__).resolve().parents[3]
+android = sdk / 'platforms/android-36/android.jar'
+d8 = sdk / 'build-tools/37.0.0/d8'
+
+def run(*args):
+    subprocess.run([str(a) for a in args], check=True)
+
+with tempfile.TemporaryDirectory(prefix='gms-provider-tests-') as tmp:
+    out = pathlib.Path(tmp)
+    classes = out / 'classes'
+    dex = out / 'dex'
+    classes.mkdir()
+    dex.mkdir()
+    src = repo / 'lib/src/app/grapheneos/gmscompat/lib'
+    tests = repo / 'lib/tests/providerinstaller'
+    run('javac', '--release', '17', '-cp', android, '-d', classes,
+        tests / 'compile-only/android/os/BinderWrapper.java',
+        *sorted((src / 'providerinstaller').glob('*.java')),
+        src / 'util/ServiceConnectionWrapper.java', *sorted(tests.glob('*Test.java')))
+    # The hidden API stub is compile-only; Android supplies the real class at runtime.
+    run('jar', 'cf', out / 'platform-signature.jar', '-C', classes, 'android')
+    run(d8, '--lib', android, '--lib', out / 'platform-signature.jar', '--output', dex,
+        *sorted((classes / 'app').rglob('*.class')))
+    target = '/data/local/tmp/gmscompat-provider-test.dex'
+    run('adb', '-s', serial, 'push', dex / 'classes.dex', target)
+    run('adb', '-s', serial, 'shell', 'app_process', '-Djava.class.path=' + target,
+        '/system/bin', 'app.grapheneos.gmscompat.lib.providerinstaller.ProviderInstallerCompatTest')


### PR DESCRIPTION
ProviderInstaller's fallback can supply a GmsCore package context to code running in a client app. In an Android 17 downstream ROM capture, Wallet fell back after `com.google.android.gms.providerinstaller.dynamite` could not load; ProviderInstaller's Phenotype registration then failed with `SecurityException: Unknown calling package name 'com.google.android.gms'`.

This draft proposes correcting the client identity at the Phenotype service connection. For broker transaction 46 and service ID 51, the wrapper replaces a claimed GmsCore package with the host application's package. It checks the host context UID, excludes GmsCore and cross-user bindings, and requires the expected service action, package and Binder descriptor. Receiver-side UID/package validation is unchanged.

The Parcel helper retains callback Binder references, unknown fields and trailing data. Unsupported or malformed requests pass through unchanged. Existing Play Integrity connection handling takes precedence.

### Evidence and validation

- Inspected the installed Wallet 26.33.969972112, Play services 26.29.32 and GmsCompatLib version 102, together with the downstream framework. Wallet's fallback explicitly creates and passes a GmsCore package context; the broker client derives the calling-package field from its context.
- Compiled the new helper/wrapper and standalone tests. Passed 56 assertions on the device using Android's real Parcel, Binder and BinderWrapper, including identity substitution, shorter/longer strings, Binder preservation, malformed inputs, pass-through paths and connection lifecycle callbacks.
- `git diff --check` passes. A reproducible test runner is included under `lib/tests/providerinstaller`.

### Remaining work / scope questions

- This was observed on a modified VoltageOS Android 17 device with app hooks enabled, not an unmodified GrapheneOS installation. Upstream reproducibility and attribution remain unverified.
- No full platform/Soong build or signed-library deployment has been performed. The tests use local Binder transactions; cross-process behavior and the actual app binding path still need validation.
- Resolved intents without the explicit package/action are currently passed through. The tested application must be checked to ensure its live binding reaches the wrapper.
- The wrapper targets matching Phenotype requests from host apps, not only ProviderInstaller call stacks. Maintainer feedback on scope and the preferred integration point would be useful.
- This does not establish a fix for Wallet device eligibility or attestation. ProviderInstaller's cryptographic provider fallback already completed in the observed capture.

Opening as a draft for design review before platform integration and end-to-end testing.
