### PR TITLE
config: disable unsupported Gesture Exchange

### DIFF
--- a/gmscompat_config
+++ b/gmscompat_config
@@ -30,6 +30,12 @@ PromoFeature__enabled perms-none-of android.permission.ACCESS_COARSE_LOCATION fa
 # below for increased stability
 Passkeys__client_data_hash_override_for_security_keys true
 
+[com.google.android.gms.gestureexchange#com.google.android.gms]
+# Gesture Exchange requires privileged NFC, secure settings and process state
+# integration. Disable its master flag to make GmsCore disable every component
+# in the module.
+45751209 false
+
 [com.google.android.gms.personalsafety]
 # requires privileged LOCK_DEVICE permission, though other Phenotype flags can also make it fallback
 # to DevicePolicyManager lockNow
@@ -344,6 +350,9 @@ isUserOfType false
 
 [[force_ComponentEnabledSettings]]
 [com.google.android.gms]
+# GestureExchangeService crashes the persistent GmsCore process when it queries its UID importance
+# without PACKAGE_USAGE_STATS, plus it requires more privileges to even work
+disable com.google.android.gms.gestureexchange.service.GestureExchangeService
 # causes chain crashes on Pixel Tablet due to the missing Dock Manager app
 disable com.google.android.gms.homegraph.PersistentListenerService
 disable com.google.android.gms.update.SystemUpdateGcmTaskService


### PR DESCRIPTION
Gesture Exchange requires privileged NFC, secure settings and process state integration which is not available to sandboxed GmsCore. Force its master flag explicitly to false and force-disable the crashing service.

On 11th-gen Pixels, the server seems to be setting this Phenotype flag to true. For other Pixel generations, it seems to be not enabled yet. However, according to https://blog.google/products-and-platforms/platforms/android/tap-to-share-android/, this appears to be rolling out to "Pixel 6 and newer devices" and will "expand to more Android devices by the end of the year," so we might as well do this to prepare.

From 11th gen Pixel, it causes GmsCore to crash very often:

    FATAL EXCEPTION: main
    Process: com.google.android.gms.persistent, PID: 2949
    java.lang.RuntimeException: Unable to create service com.google.android.gms.gestureexchange.service.GestureExchangeService
        at android.app.ActivityThread.handleCreateService(ActivityThread.java:5683)
        at android.app.ActivityThread.-$$Nest$mhandleCreateService(ActivityThread.java:0)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2814)
        at android.os.Handler.dispatchMessageImpl(Handler.java:142)
        at android.os.Handler.dispatchMessage(Handler.java:125)
        at android.os.Looper.loopOnce(Looper.java:296)
        at android.os.Looper.loop(Looper.java:397)
        at android.app.ActivityThread.main(ActivityThread.java:9569)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:575)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:975)
    Caused by: java.lang.SecurityException: Permission Denial: getUidProcessState from pid=2949, uid=10207 requires android.permission.PACKAGE_USAGE_STATS
        at android.os.Parcel.createExceptionOrNull(Parcel.java:3401)
        at android.os.Parcel.createException(Parcel.java:3385)
        at android.os.Parcel.readException(Parcel.java:3361)
        at android.os.Parcel.readException(Parcel.java:3303)
        at android.app.IActivityManager$Stub$Proxy.getUidProcessState(IActivityManager.java:6064)
        at android.app.ActivityManager.getUidImportance(ActivityManager.java:4950)
        at com.google.android.gms.gestureexchange.service.GestureExchangeChimeraService.onCreate(:com.google.android.gms@263234035@26.32.34 (260400-968093310):271)
        at acdw.onCreate(:com.google.android.gms@263234035@26.32.34 (260400-968093310):23)
        at bfzm.onCreate(:com.google.android.gms@263234035@26.32.34 (260400-968093310):28)
        at android.app.ActivityThread.handleCreateService(ActivityThread.java:5672)
        ... 10 more